### PR TITLE
fix(build): bundle runtime deps into browser bundle and add error overlay

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -188,6 +188,31 @@
     }
     .bench-metric-tab:hover { border-color: #4fc3f7; color: #ccc; }
     .bench-metric-tab.active { border-color: #4fc3f7; color: #4fc3f7; background: #1a1a2e; }
+
+    /* Error overlay */
+    .error-overlay {
+      display: none; position: fixed; bottom: 0; left: 0; right: 0;
+      max-height: 40vh; overflow-y: auto; z-index: 10000;
+      background: #1a0000; border-top: 2px solid #ef5350;
+      font-family: monospace; font-size: 0.82rem; color: #ffcdd2;
+    }
+    .error-overlay.visible { display: block; }
+    .error-header {
+      position: sticky; top: 0; background: #2c0b0b;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 8px 14px; border-bottom: 1px solid #4e1a1a;
+    }
+    .error-header span { font-weight: bold; color: #ef5350; }
+    .error-header-btns { display: flex; gap: 8px; }
+    .error-header-btns button {
+      background: none; border: 1px solid #ef5350; color: #ef5350;
+      padding: 3px 10px; border-radius: 4px; font-size: 0.78rem;
+      cursor: pointer; font-family: inherit;
+    }
+    .error-header-btns button:hover { background: #ef5350; color: #fff; }
+    .error-list { padding: 10px 14px; }
+    .error-entry { padding: 6px 0; border-bottom: 1px solid #3a1111; white-space: pre-wrap; word-break: break-all; }
+    .error-entry:last-child { border-bottom: none; }
   </style>
 </head>
 <body>
@@ -240,6 +265,67 @@
   </div>
 
   <div class="grid" id="examples-grid"></div>
+
+  <!-- Error overlay for mobile debugging -->
+  <div class="error-overlay" id="error-overlay">
+    <div class="error-header">
+      <span id="error-count">0 error(s)</span>
+      <div class="error-header-btns">
+        <button id="error-copy-btn">Copy errors</button>
+        <button id="error-close-btn">Close</button>
+      </div>
+    </div>
+    <div class="error-list" id="error-list"></div>
+  </div>
+  <script>
+  (function(){
+    var overlay = document.getElementById('error-overlay');
+    var list = document.getElementById('error-list');
+    var countEl = document.getElementById('error-count');
+    var errors = [];
+
+    function addError(msg) {
+      errors.push(msg);
+      var entry = document.createElement('div');
+      entry.className = 'error-entry';
+      entry.textContent = msg;
+      list.appendChild(entry);
+      countEl.textContent = errors.length + ' error(s)';
+      overlay.classList.add('visible');
+    }
+
+    window.addEventListener('error', function(e) {
+      var msg = (e.message || 'Unknown error');
+      if (e.filename) msg += '\n  at ' + e.filename + ':' + e.lineno + ':' + e.colno;
+      if (e.error && e.error.stack) msg += '\n' + e.error.stack;
+      addError(msg);
+    });
+
+    window.addEventListener('unhandledrejection', function(e) {
+      var msg = 'Unhandled Promise Rejection: ';
+      if (e.reason instanceof Error) {
+        msg += e.reason.message;
+        if (e.reason.stack) msg += '\n' + e.reason.stack;
+      } else {
+        msg += String(e.reason);
+      }
+      addError(msg);
+    });
+
+    document.getElementById('error-copy-btn').addEventListener('click', function() {
+      var text = errors.join('\n\n---\n\n');
+      navigator.clipboard.writeText(text).then(function() {
+        var btn = document.getElementById('error-copy-btn');
+        btn.textContent = 'Copied!';
+        setTimeout(function(){ btn.textContent = 'Copy errors'; }, 1500);
+      });
+    });
+
+    document.getElementById('error-close-btn').addEventListener('click', function() {
+      overlay.classList.remove('visible');
+    });
+  })();
+  </script>
 
   <script type="importmap">
   {

--- a/scripts/stubs/three-loaders.js
+++ b/scripts/stubs/three-loaders.js
@@ -1,5 +1,5 @@
-// Stub for unused three.js loaders pulled in by @newkrok/three-utils.
-// Provides no-op constructors so top-level `new XLoader()` won't throw.
+// Stub for unused three.js add-ons pulled in by @newkrok/three-utils.
+// Provides no-op constructors so imports won't throw.
 const noop = function () {};
 noop.prototype.load = noop;
 noop.prototype.parse = noop;
@@ -7,3 +7,4 @@ noop.prototype.parse = noop;
 export const GLTFLoader = noop;
 export const FBXLoader = noop;
 export const PositionalAudioHelper = noop;
+export const clone = noop;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'tsup';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
-const sharedExternal = [
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const libraryExternal = [
   'three',
   '@newkrok/three-utils',
   'easing-functions',
@@ -16,10 +20,11 @@ export default defineConfig([
     sourcemap: true,
     clean: true,
     outDir: 'dist',
-    external: sharedExternal,
+    external: libraryExternal,
     treeshake: true,
   },
-  // Minified browser bundle
+  // Minified browser bundle — all deps except "three" are inlined so the
+  // bundle works when loaded directly from a CDN without a bundler.
   {
     entry: { 'three-particles.min': 'src/index.ts' },
     format: ['esm'],
@@ -27,8 +32,39 @@ export default defineConfig([
     outExtension: () => ({ js: '.js' }),
     sourcemap: true,
     minify: 'terser',
-    external: sharedExternal,
+    noExternal: [/.*/],
     treeshake: true,
+    esbuildPlugins: [
+      {
+        // Handle three.js externals for the browser bundle:
+        // - "three" core and Gyroscope (actually used) → external
+        // - Unused loaders/helpers from @newkrok/three-utils → stubbed
+        name: 'three-browser-externals',
+        setup(build) {
+          const stub = path.resolve(__dirname, 'scripts/stubs/three-loaders.js');
+          const stubbed = new Set([
+            'three/examples/jsm/loaders/FBXLoader.js',
+            'three/examples/jsm/loaders/GLTFLoader.js',
+            'three/examples/jsm/helpers/PositionalAudioHelper.js',
+            'three/examples/jsm/utils/SkeletonUtils.js',
+          ]);
+          const kept = new Set([
+            'three',
+            'three/examples/jsm/misc/Gyroscope.js',
+          ]);
+          build.onResolve({ filter: /^three(\/|$)/ }, (args) => {
+            if (stubbed.has(args.path)) {
+              return { path: stub };
+            }
+            if (kept.has(args.path)) {
+              return { path: args.path, external: true };
+            }
+            // Any other three/* import — keep external
+            return { path: args.path, external: true };
+          });
+        },
+      },
+    ],
     terserOptions: {
       compress: {
         drop_console: true,


### PR DESCRIPTION
The tsup migration (v2.6.3) externalized @newkrok/three-utils,
easing-functions and three-noise from the minified browser bundle.
When loaded from CDN, the browser cannot resolve these bare module
specifiers, breaking all demos on the examples page.

Fix: use noExternal to inline all deps into three-particles.min.js,
with an esbuild plugin to stub unused three.js add-ons (FBXLoader,
GLTFLoader, etc.) and keep only "three" core + Gyroscope as externals.

Also adds a fixed-position error overlay to the examples page that
captures window errors and unhandled rejections, with a "Copy errors"
button for easy mobile debugging.

Co-Authored-By: Claude <noreply@anthropic.com>