### PR TITLE
fix: resolve WORLD space sub-emitter premature disposal and wrapper scene leak

### DIFF
--- a/src/__tests__/three-particles-sub-emitters.test.ts
+++ b/src/__tests__/three-particles-sub-emitters.test.ts
@@ -1,5 +1,8 @@
 import * as THREE from 'three';
-import { SubEmitterTrigger } from '../js/effects/three-particles/three-particles-enums.js';
+import {
+  SimulationSpace,
+  SubEmitterTrigger,
+} from '../js/effects/three-particles/three-particles-enums.js';
 import { createParticleSystem } from '../js/effects/three-particles/three-particles.js';
 import { ParticleSystem } from '../js/effects/three-particles/types.js';
 
@@ -319,6 +322,86 @@ describe('Sub-emitters', () => {
         }
       }
       expect(totalSubActive).toBeGreaterThan(0);
+
+      ps.dispose();
+    });
+  });
+
+  describe('WORLD space sub-emitters', () => {
+    it('should not prematurely dispose WORLD space sub-emitters that have active particles', () => {
+      const scene = new THREE.Group();
+      const startTime = 1000;
+
+      // Parent: LOCAL space, burst(1) at t=0 + continuous emission to trigger cleanup
+      // Sub-emitter: WORLD space, burst(5) at t=0, 3s particle lifetime, maxInstances=1
+      const ps = createParticleSystem(
+        {
+          maxParticles: 10,
+          duration: 5,
+          looping: true,
+          startLifetime: 5,
+          startSpeed: 1,
+          startSize: 1,
+          startOpacity: 1,
+          startRotation: 0,
+          emission: {
+            rateOverTime: 50,
+            rateOverDistance: 0,
+            bursts: [{ time: 0, count: 1 }],
+          },
+          subEmitters: [
+            {
+              trigger: SubEmitterTrigger.BIRTH,
+              config: {
+                maxParticles: 10,
+                duration: 5,
+                looping: false,
+                startLifetime: 3,
+                startSpeed: 0,
+                startSize: 1,
+                startOpacity: 1,
+                startRotation: 0,
+                simulationSpace: SimulationSpace.WORLD,
+                emission: {
+                  rateOverTime: 0,
+                  rateOverDistance: 0,
+                  bursts: [{ time: 0, count: 5 }],
+                },
+              },
+              maxInstances: 1,
+            },
+          ],
+        } as any,
+        startTime
+      );
+
+      scene.add(ps.instance);
+
+      // t=0: initial burst(1) fires → sub-emitter #1 (WORLD space) spawned
+      // Sub-emitter #1 is updated same-frame: burst(5) fires → 5 active particles
+      ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+
+      // t=100ms: rateOverTime=50 emits 5 more parent particles
+      // Each birth attempt triggers cleanupCompletedInstances since maxInstances=1
+      // Sub-emitter #1 has 5 active particles (3s lifetime, only 100ms old)
+      // Fix: should NOT be disposed; Bug: would be disposed (isActiveArr was undefined for WORLD)
+      ps.update({ now: startTime + 100, delta: 0.1, elapsed: 0.1 });
+
+      // Sub-emitter wrapper must still be in scene
+      expect(scene.children.length).toBe(2);
+
+      // The sub-emitter wrapper's child (THREE.Points) must have active particles
+      const subWrapper = scene.children.find((c) => c !== ps.instance)!;
+      expect(subWrapper).toBeDefined();
+      const subPoints = subWrapper.children[0] as THREE.Points;
+      expect(subPoints?.geometry?.attributes?.isActive).toBeDefined();
+
+      const isActiveArr = subPoints.geometry.attributes.isActive.array;
+      let activeCount = 0;
+      for (let i = 0; i < isActiveArr.length; i++) {
+        if (isActiveArr[i]) activeCount++;
+      }
+      expect(activeCount).toBe(5);
 
       ps.dispose();
     });

--- a/src/__tests__/three-particles-world-space.test.ts
+++ b/src/__tests__/three-particles-world-space.test.ts
@@ -155,6 +155,19 @@ describe('World Simulation Space', () => {
     ps.dispose();
   });
 
+  it('should remove the Gyroscope wrapper from scene when disposed', () => {
+    const scene = new THREE.Group();
+    const { ps, step } = createWorldSpaceSystem();
+    scene.add(ps.instance);
+
+    step(16);
+    expect(scene.children.length).toBe(1);
+
+    ps.dispose();
+
+    expect(scene.children.length).toBe(0);
+  });
+
   it('should handle pause/resume in world space', () => {
     const { ps, step } = createWorldSpaceSystem();
 

--- a/src/js/effects/three-particles/three-particles.ts
+++ b/src/js/effects/three-particles/three-particles.ts
@@ -365,6 +365,7 @@ const destroyParticleSystem = (particleSystem: THREE.Points) => {
 
       if (savedParticleSystem.parent)
         savedParticleSystem.parent.remove(savedParticleSystem);
+      if (wrapper?.parent) wrapper.parent.remove(wrapper);
       return false;
     }
   );
@@ -1043,8 +1044,11 @@ export const createParticleSystem = (
   const cleanupCompletedInstances = (instances: Array<ParticleSystem>) => {
     for (let i = instances.length - 1; i >= 0; i--) {
       const sub = instances[i];
-      const points = sub.instance as THREE.Points;
-      const isActiveArr = points.geometry?.attributes?.isActive?.array;
+      const points =
+        sub.instance instanceof THREE.Points
+          ? sub.instance
+          : (sub.instance.children[0] as THREE.Points | undefined);
+      const isActiveArr = points?.geometry?.attributes?.isActive?.array;
       if (!isActiveArr) {
         sub.dispose();
         instances.splice(i, 1);


### PR DESCRIPTION
Two bugs fixed in sub-emitter handling for SimulationSpace.WORLD:

1. cleanupCompletedInstances cast sub.instance directly to THREE.Points,
   but WORLD space sub-emitters use a Gyroscope wrapper as their instance.
   This caused isActiveArr to be undefined, so every sub-emitter with active
   particles was immediately disposed when maxInstances was hit, making all
   sub-particles vanish at once.

   Fix: resolve the actual THREE.Points via instanceof check, falling back to
   the first child of the wrapper.

2. destroyParticleSystem removed the THREE.Points from the Gyroscope but did
   not remove the Gyroscope wrapper itself from the scene, leaving empty
   Object3D nodes accumulating in the scene graph.

   Fix: also remove wrapper from its parent after removing the particle system.

Co-Authored-By: Claude <noreply@anthropic.com>