### PR TITLE
test: add coverage gap tests and integration tests

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -280,7 +280,7 @@ npx typedoc               # Generate documentation
 | PR checks (lint + test + build + bundle size + CodeQL) | ✅ Complete |
 | Bundle size monitoring (150 KB limit) | ✅ Complete |
 | Performance benchmark suite | ✅ Complete |
-| Test coverage (99.4% stmt, 96.4% branch, 546 tests) | ✅ Target ≥90% stmt, ≥80% branch |
+| Test coverage (100% stmt, 99.5% branch, 580 tests) | ✅ Target ≥90% stmt, ≥80% branch |
 | Sub-emitters | ✅ Complete |
 | Force fields / Attractors | ✅ Complete |
 | GPU instancing (`RendererType.INSTANCED`) | ✅ Complete |

--- a/src/__tests__/three-particles-coverage-gaps.test.ts
+++ b/src/__tests__/three-particles-coverage-gaps.test.ts
@@ -4,66 +4,12 @@ import {
   ForceFieldType,
   LifeTimeCurve,
   RendererType,
-  SimulationSpace,
   SubEmitterTrigger,
 } from '../js/effects/three-particles/three-particles-enums.js';
 import { applyForceFields } from '../js/effects/three-particles/three-particles-forces.js';
-import {
-  serializeParticleSystem,
-  deserializeParticleSystem,
-} from '../js/effects/three-particles/three-particles-serialization.js';
+import { deserializeParticleSystem } from '../js/effects/three-particles/three-particles-serialization.js';
 import { createParticleSystem } from '../js/effects/three-particles/three-particles.js';
-import type {
-  NormalizedForceFieldConfig,
-  ParticleSystem,
-} from '../js/effects/three-particles/types.js';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-const createTestSystem = (
-  config: Record<string, unknown> = {},
-  startTime = 1000
-) => {
-  const ps = createParticleSystem(
-    {
-      maxParticles: 10,
-      duration: 5,
-      looping: true,
-      startLifetime: 0.2,
-      startSpeed: 1,
-      startSize: 1,
-      startOpacity: 1,
-      startRotation: 0,
-      emission: { rateOverTime: 50, rateOverDistance: 0 },
-      ...config,
-    } as any,
-    startTime
-  );
-
-  const step = (timeOffsetMs: number, deltaMs: number = 16) => {
-    ps.update({
-      now: startTime + timeOffsetMs,
-      delta: deltaMs / 1000,
-      elapsed: timeOffsetMs / 1000,
-    });
-  };
-
-  return { ps, step, startTime };
-};
-
-const subEmitterConfig = {
-  maxParticles: 5,
-  duration: 1,
-  looping: false,
-  startLifetime: 0.3,
-  startSpeed: 0.5,
-  startSize: 0.5,
-  startOpacity: 1,
-  startRotation: 0,
-  emission: { rateOverTime: 5, rateOverDistance: 0 },
-};
+import type { NormalizedForceFieldConfig } from '../js/effects/three-particles/types.js';
 
 // ---------------------------------------------------------------------------
 // Gap 1: three-particles.ts:1122-1124 — Sub-emitter cleanup when isActiveArr
@@ -137,13 +83,18 @@ describe('sub-emitter cleanup — missing isActiveArr branch', () => {
       subPoints.geometry.deleteAttribute('instanceIsActive');
     }
 
+    // Verify sub-emitters were created
+    const subCount = scene.children.filter((c) => c !== ps.instance).length;
+    expect(subCount).toBeGreaterThan(0);
+
     // Next update triggers cleanupCompletedInstances which should
     // hit the !isActiveArr branch and dispose the corrupted sub-emitter
-    ps.update({ now: startTime + 100, delta: 0.1, elapsed: 0.1 });
-    ps.update({ now: startTime + 200, delta: 0.1, elapsed: 0.2 });
+    // (dispose removes from internal tracking; scene graph removal is separate)
+    expect(() => {
+      ps.update({ now: startTime + 100, delta: 0.1, elapsed: 0.1 });
+      ps.update({ now: startTime + 200, delta: 0.1, elapsed: 0.2 });
+    }).not.toThrow();
 
-    // The sabotaged sub-emitter should have been removed from the scene
-    // (disposed via the !isActiveArr fallback path)
     ps.dispose();
   });
 
@@ -209,9 +160,15 @@ describe('sub-emitter cleanup — missing isActiveArr branch', () => {
       }
     }
 
+    // Verify sub-emitters were created
+    const subCount = scene.children.filter((c) => c !== ps.instance).length;
+    expect(subCount).toBeGreaterThan(0);
+
     // Should dispose the corrupted sub-emitter via the !isActiveArr branch
-    ps.update({ now: startTime + 100, delta: 0.1, elapsed: 0.1 });
-    ps.update({ now: startTime + 300, delta: 0.2, elapsed: 0.3 });
+    expect(() => {
+      ps.update({ now: startTime + 100, delta: 0.1, elapsed: 0.1 });
+      ps.update({ now: startTime + 300, delta: 0.2, elapsed: 0.3 });
+    }).not.toThrow();
 
     ps.dispose();
   });

--- a/src/__tests__/three-particles-coverage-gaps.test.ts
+++ b/src/__tests__/three-particles-coverage-gaps.test.ts
@@ -1,0 +1,969 @@
+import * as THREE from 'three';
+import {
+  ForceFieldFalloff,
+  ForceFieldType,
+  LifeTimeCurve,
+  RendererType,
+  SimulationSpace,
+  SubEmitterTrigger,
+} from '../js/effects/three-particles/three-particles-enums.js';
+import { applyForceFields } from '../js/effects/three-particles/three-particles-forces.js';
+import {
+  serializeParticleSystem,
+  deserializeParticleSystem,
+} from '../js/effects/three-particles/three-particles-serialization.js';
+import { createParticleSystem } from '../js/effects/three-particles/three-particles.js';
+import type {
+  NormalizedForceFieldConfig,
+  ParticleSystem,
+} from '../js/effects/three-particles/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const createTestSystem = (
+  config: Record<string, unknown> = {},
+  startTime = 1000
+) => {
+  const ps = createParticleSystem(
+    {
+      maxParticles: 10,
+      duration: 5,
+      looping: true,
+      startLifetime: 0.2,
+      startSpeed: 1,
+      startSize: 1,
+      startOpacity: 1,
+      startRotation: 0,
+      emission: { rateOverTime: 50, rateOverDistance: 0 },
+      ...config,
+    } as any,
+    startTime
+  );
+
+  const step = (timeOffsetMs: number, deltaMs: number = 16) => {
+    ps.update({
+      now: startTime + timeOffsetMs,
+      delta: deltaMs / 1000,
+      elapsed: timeOffsetMs / 1000,
+    });
+  };
+
+  return { ps, step, startTime };
+};
+
+const subEmitterConfig = {
+  maxParticles: 5,
+  duration: 1,
+  looping: false,
+  startLifetime: 0.3,
+  startSpeed: 0.5,
+  startSize: 0.5,
+  startOpacity: 1,
+  startRotation: 0,
+  emission: { rateOverTime: 5, rateOverDistance: 0 },
+};
+
+// ---------------------------------------------------------------------------
+// Gap 1: three-particles.ts:1122-1124 — Sub-emitter cleanup when isActiveArr
+//        is not found (e.g. disposed/corrupted sub-emitter geometry).
+// ---------------------------------------------------------------------------
+
+describe('sub-emitter cleanup — missing isActiveArr branch', () => {
+  it('should dispose sub-emitter instance when geometry attributes are missing', () => {
+    const scene = new THREE.Group();
+    const startTime = 1000;
+
+    const ps = createParticleSystem(
+      {
+        maxParticles: 10,
+        duration: 5,
+        looping: true,
+        startLifetime: 0.2,
+        startSpeed: 1,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: {
+          rateOverTime: 50,
+          rateOverDistance: 0,
+          bursts: [{ time: 0, count: 1 }],
+        },
+        subEmitters: [
+          {
+            trigger: SubEmitterTrigger.BIRTH,
+            config: {
+              maxParticles: 5,
+              duration: 0.5,
+              looping: false,
+              startLifetime: 0.1,
+              startSpeed: 0,
+              startSize: 1,
+              startOpacity: 1,
+              startRotation: 0,
+              emission: {
+                rateOverTime: 0,
+                rateOverDistance: 0,
+                bursts: [{ time: 0, count: 1 }],
+              },
+            },
+            maxInstances: 2,
+          },
+        ],
+      } as any,
+      startTime
+    );
+
+    scene.add(ps.instance);
+
+    // Step 1: emit burst → spawns sub-emitter
+    ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+
+    // Find the sub-emitter in the scene
+    const subInstances = scene.children.filter((c) => c !== ps.instance);
+    expect(subInstances.length).toBeGreaterThan(0);
+
+    // Sabotage the sub-emitter's geometry by removing its attributes
+    const subInstance = subInstances[0];
+    const subPoints =
+      subInstance instanceof THREE.Points
+        ? subInstance
+        : (subInstance.children[0] as THREE.Points | undefined);
+
+    if (subPoints?.geometry) {
+      // Delete the isActive attribute to simulate a corrupted/disposed state
+      subPoints.geometry.deleteAttribute('isActive');
+      subPoints.geometry.deleteAttribute('instanceIsActive');
+    }
+
+    // Next update triggers cleanupCompletedInstances which should
+    // hit the !isActiveArr branch and dispose the corrupted sub-emitter
+    ps.update({ now: startTime + 100, delta: 0.1, elapsed: 0.1 });
+    ps.update({ now: startTime + 200, delta: 0.1, elapsed: 0.2 });
+
+    // The sabotaged sub-emitter should have been removed from the scene
+    // (disposed via the !isActiveArr fallback path)
+    ps.dispose();
+  });
+
+  it('should dispose sub-emitter when instance is not Points or Mesh and has no children', () => {
+    const scene = new THREE.Group();
+    const startTime = 1000;
+
+    const ps = createParticleSystem(
+      {
+        maxParticles: 10,
+        duration: 5,
+        looping: true,
+        startLifetime: 0.2,
+        startSpeed: 1,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: {
+          rateOverTime: 50,
+          rateOverDistance: 0,
+          bursts: [{ time: 0, count: 1 }],
+        },
+        subEmitters: [
+          {
+            trigger: SubEmitterTrigger.BIRTH,
+            config: {
+              maxParticles: 5,
+              duration: 0.5,
+              looping: false,
+              startLifetime: 0.1,
+              startSpeed: 0,
+              startSize: 1,
+              startOpacity: 1,
+              startRotation: 0,
+              emission: {
+                rateOverTime: 0,
+                rateOverDistance: 0,
+                bursts: [{ time: 0, count: 1 }],
+              },
+            },
+            maxInstances: 2,
+          },
+        ],
+      } as any,
+      startTime
+    );
+
+    scene.add(ps.instance);
+
+    ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+
+    // Sabotage: remove geometry attributes so isActiveArr is undefined
+    const subInstances = scene.children.filter((c) => c !== ps.instance);
+    for (const sub of subInstances) {
+      const subPoints =
+        sub instanceof THREE.Points
+          ? sub
+          : (sub.children[0] as THREE.Points | undefined);
+      if (subPoints?.geometry) {
+        // Delete both possible attribute names
+        subPoints.geometry.deleteAttribute('isActive');
+        subPoints.geometry.deleteAttribute('instanceIsActive');
+      }
+    }
+
+    // Should dispose the corrupted sub-emitter via the !isActiveArr branch
+    ps.update({ now: startTime + 100, delta: 0.1, elapsed: 0.1 });
+    ps.update({ now: startTime + 300, delta: 0.2, elapsed: 0.3 });
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gap 2: three-particles.ts:1200-1201 — onBeforeRender callback execution
+// ---------------------------------------------------------------------------
+
+describe('instanced renderer onBeforeRender callback', () => {
+  it('should update viewportHeight uniform from renderer size and pixel ratio', () => {
+    const ps = createParticleSystem(
+      {
+        maxParticles: 10,
+        duration: 5,
+        looping: true,
+        startLifetime: 1,
+        startSpeed: 1,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: { rateOverTime: 10, rateOverDistance: 0 },
+        renderer: { rendererType: RendererType.INSTANCED },
+      } as any,
+      1000
+    );
+
+    const mesh = ps.instance as THREE.Mesh;
+    const material = mesh.material as THREE.ShaderMaterial;
+
+    expect(mesh.onBeforeRender).toBeDefined();
+
+    // Create a mock WebGL renderer
+    const mockRenderer = {
+      getSize: (target: THREE.Vector2) => target.set(800, 600),
+      getPixelRatio: () => 2,
+    } as unknown as THREE.WebGLRenderer;
+
+    // Invoke the onBeforeRender callback
+    mesh.onBeforeRender(
+      mockRenderer,
+      null as any,
+      null as any,
+      null as any,
+      null as any,
+      null as any
+    );
+
+    // viewportHeight should be size.y * pixelRatio = 600 * 2 = 1200
+    expect(material.uniforms.viewportHeight.value).toBe(1200);
+
+    ps.dispose();
+  });
+
+  it('should handle pixelRatio of 1 (non-retina display)', () => {
+    const ps = createParticleSystem(
+      {
+        maxParticles: 10,
+        duration: 5,
+        looping: true,
+        startLifetime: 1,
+        startSpeed: 1,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: { rateOverTime: 10, rateOverDistance: 0 },
+        renderer: { rendererType: RendererType.INSTANCED },
+      } as any,
+      1000
+    );
+
+    const mesh = ps.instance as THREE.Mesh;
+    const material = mesh.material as THREE.ShaderMaterial;
+
+    const mockRenderer = {
+      getSize: (target: THREE.Vector2) => target.set(1920, 1080),
+      getPixelRatio: () => 1,
+    } as unknown as THREE.WebGLRenderer;
+
+    mesh.onBeforeRender(
+      mockRenderer,
+      null as any,
+      null as any,
+      null as any,
+      null as any,
+      null as any
+    );
+
+    expect(material.uniforms.viewportHeight.value).toBe(1080);
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gap 3: three-particles-forces.ts:145 — DIRECTIONAL branch in applyForceFields
+//        dispatched via calculateValue (strength as curve, not just a number)
+// ---------------------------------------------------------------------------
+
+describe('applyForceFields — DIRECTIONAL branch with curve strength', () => {
+  let velocity: THREE.Vector3;
+  let positionArr: Float32Array;
+
+  beforeEach(() => {
+    velocity = new THREE.Vector3(0, 0, 0);
+    positionArr = new Float32Array([5, 0, 0]);
+  });
+
+  it('should apply DIRECTIONAL force when strength is a min/max range', () => {
+    const field: NormalizedForceFieldConfig = {
+      isActive: true,
+      type: ForceFieldType.DIRECTIONAL,
+      position: new THREE.Vector3(0, 0, 0),
+      direction: new THREE.Vector3(0, 1, 0),
+      strength: { min: 5, max: 5 },
+      range: Infinity,
+      falloff: ForceFieldFalloff.LINEAR,
+    };
+
+    applyForceFields({
+      particleSystemId: 0,
+      forceFields: [field],
+      velocity,
+      positionArr,
+      positionIndex: 0,
+      delta: 1,
+      systemLifetimePercentage: 0,
+    });
+
+    expect(velocity.y).toBeCloseTo(5);
+  });
+
+  it('should skip unknown field type without error', () => {
+    const field: NormalizedForceFieldConfig = {
+      isActive: true,
+      type: 'UNKNOWN' as any,
+      position: new THREE.Vector3(0, 0, 0),
+      direction: new THREE.Vector3(0, 1, 0),
+      strength: 5,
+      range: Infinity,
+      falloff: ForceFieldFalloff.LINEAR,
+    };
+
+    applyForceFields({
+      particleSystemId: 0,
+      forceFields: [field],
+      velocity,
+      positionArr,
+      positionIndex: 0,
+      delta: 1,
+      systemLifetimePercentage: 0,
+    });
+
+    // Velocity should remain unchanged — unknown type does nothing
+    expect(velocity.x).toBe(0);
+    expect(velocity.y).toBe(0);
+    expect(velocity.z).toBe(0);
+  });
+
+  it('should apply POINT then DIRECTIONAL when mixed in same array', () => {
+    const pointField: NormalizedForceFieldConfig = {
+      isActive: true,
+      type: ForceFieldType.POINT,
+      position: new THREE.Vector3(0, 0, 0),
+      direction: new THREE.Vector3(0, 1, 0),
+      strength: 10,
+      range: Infinity,
+      falloff: ForceFieldFalloff.LINEAR,
+    };
+    const directionalField: NormalizedForceFieldConfig = {
+      isActive: true,
+      type: ForceFieldType.DIRECTIONAL,
+      position: new THREE.Vector3(0, 0, 0),
+      direction: new THREE.Vector3(0, 0, 1),
+      strength: 7,
+      range: Infinity,
+      falloff: ForceFieldFalloff.LINEAR,
+    };
+
+    applyForceFields({
+      particleSystemId: 0,
+      forceFields: [pointField, directionalField],
+      velocity,
+      positionArr,
+      positionIndex: 0,
+      delta: 1,
+      systemLifetimePercentage: 0,
+    });
+
+    // Point: pulls toward origin on X axis
+    expect(velocity.x).toBeLessThan(0);
+    // Directional: pushes on Z axis
+    expect(velocity.z).toBeCloseTo(7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gap 4: three-particles-serialization.ts:185 — deserializeVector2 defaults
+// ---------------------------------------------------------------------------
+
+describe('deserializeVector2 — default value branches', () => {
+  it('should default both x and y to 1 when empty object is provided', () => {
+    const json = JSON.stringify({
+      _version: 1,
+      textureSheetAnimation: {
+        tiles: {},
+        fps: 10,
+      },
+    });
+    const result = deserializeParticleSystem(json);
+    expect(result.textureSheetAnimation!.tiles!.x).toBe(1);
+    expect(result.textureSheetAnimation!.tiles!.y).toBe(1);
+  });
+
+  it('should default x to 1 when only y is provided', () => {
+    const json = JSON.stringify({
+      _version: 1,
+      textureSheetAnimation: {
+        tiles: { y: 3 },
+        fps: 10,
+      },
+    });
+    const result = deserializeParticleSystem(json);
+    expect(result.textureSheetAnimation!.tiles!.x).toBe(1);
+    expect(result.textureSheetAnimation!.tiles!.y).toBe(3);
+  });
+
+  it('should use provided values when both x and y are specified', () => {
+    const json = JSON.stringify({
+      _version: 1,
+      textureSheetAnimation: {
+        tiles: { x: 4, y: 2 },
+        fps: 10,
+      },
+    });
+    const result = deserializeParticleSystem(json);
+    expect(result.textureSheetAnimation!.tiles!.x).toBe(4);
+    expect(result.textureSheetAnimation!.tiles!.y).toBe(2);
+  });
+
+  it('should return undefined for non-object tiles value', () => {
+    const json = JSON.stringify({
+      _version: 1,
+      textureSheetAnimation: {
+        tiles: 'invalid',
+        fps: 10,
+      },
+    });
+    const result = deserializeParticleSystem(json);
+    expect(result.textureSheetAnimation!.tiles).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gap 5: three-particles.ts:516-519 — force field toVector3 fallback (no
+//        position or direction provided)
+// ---------------------------------------------------------------------------
+
+describe('force field normalization — missing position/direction', () => {
+  it('should use default position and direction when not provided', () => {
+    const startTime = 1000;
+    const ps = createParticleSystem(
+      {
+        maxParticles: 5,
+        duration: 5,
+        looping: true,
+        startLifetime: 1,
+        startSpeed: 0,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: {
+          rateOverTime: 0,
+          rateOverDistance: 0,
+          bursts: [{ time: 0, count: 1 }],
+        },
+        forceFields: [
+          {
+            // Partial position (only x, no y/z) — triggers v.y ?? 0, v.z ?? 0 fallbacks
+            type: ForceFieldType.POINT,
+            position: { x: 5 },
+            direction: { x: 1 },
+            strength: 2,
+          },
+          {
+            // Explicit undefined for position/direction — triggers fallback.clone()
+            type: ForceFieldType.DIRECTIONAL,
+            position: undefined,
+            direction: undefined,
+            strength: 5,
+          },
+        ],
+      } as any,
+      startTime
+    );
+
+    // Should not throw; force field should have default position/direction
+    ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+    ps.update({ now: startTime + 100, delta: 0.1, elapsed: 0.1 });
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gap 6: three-particles.ts:590,639 — velocityOverLifetime linear.z and
+//        orbital.z as LifetimeCurve (Bezier curve on the Z axis)
+// ---------------------------------------------------------------------------
+
+describe('velocityOverLifetime — Z-axis lifetime curves', () => {
+  it('should apply bezier curve to linear velocity Z axis', () => {
+    const startTime = 1000;
+    const ps = createParticleSystem(
+      {
+        maxParticles: 5,
+        duration: 5,
+        looping: true,
+        startLifetime: 2,
+        startSpeed: 0,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: {
+          rateOverTime: 0,
+          rateOverDistance: 0,
+          bursts: [{ time: 0, count: 3 }],
+        },
+        velocityOverLifetime: {
+          isActive: true,
+          linear: {
+            x: 0,
+            y: 0,
+            z: {
+              type: LifeTimeCurve.BEZIER,
+              bezierPoints: [
+                { x: 0, y: 0 },
+                { x: 0.25, y: 5 },
+                { x: 0.75, y: 5 },
+                { x: 1, y: 0 },
+              ],
+            },
+          },
+        },
+      } as any,
+      startTime
+    );
+
+    ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+    ps.update({ now: startTime + 500, delta: 0.5, elapsed: 0.5 });
+
+    // Particles should have moved along Z due to the bezier curve
+    const points =
+      ps.instance instanceof THREE.Points
+        ? ps.instance
+        : (ps.instance.children[0] as THREE.Points);
+    const posArr = points.geometry.attributes.position.array;
+    const isActiveArr = points.geometry.attributes.isActive.array;
+
+    let hasZMovement = false;
+    for (let i = 0; i < isActiveArr.length; i++) {
+      if (isActiveArr[i] && Math.abs(posArr[i * 3 + 2] as number) > 0.01) {
+        hasZMovement = true;
+        break;
+      }
+    }
+    expect(hasZMovement).toBe(true);
+
+    ps.dispose();
+  });
+
+  it('should apply bezier curve to orbital velocity Z axis', () => {
+    const startTime = 1000;
+    const ps = createParticleSystem(
+      {
+        maxParticles: 5,
+        duration: 5,
+        looping: true,
+        startLifetime: 2,
+        startSpeed: 0,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: {
+          rateOverTime: 0,
+          rateOverDistance: 0,
+          bursts: [{ time: 0, count: 3 }],
+        },
+        velocityOverLifetime: {
+          isActive: true,
+          orbital: {
+            x: 0,
+            y: 0,
+            z: {
+              type: LifeTimeCurve.BEZIER,
+              bezierPoints: [
+                { x: 0, y: 0 },
+                { x: 0.25, y: 3 },
+                { x: 0.75, y: 3 },
+                { x: 1, y: 0 },
+              ],
+            },
+          },
+        },
+      } as any,
+      startTime
+    );
+
+    // Should not throw — orbital Z bezier should be processed
+    ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+    ps.update({ now: startTime + 500, delta: 0.5, elapsed: 0.5 });
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gap 7: three-particles.ts:1118 — instanceIsActive branch in sub-emitter
+//        cleanup (instanced sub-emitter with instanceIsActive attribute)
+// ---------------------------------------------------------------------------
+
+describe('sub-emitter cleanup — instanced sub-emitter (instanceIsActive)', () => {
+  it('should correctly read instanceIsActive when cleaning up instanced sub-emitters', () => {
+    const scene = new THREE.Group();
+    const startTime = 1000;
+
+    // Parent: burst(5) at t=0, short lifetime (0.1s), continuous emission to trigger cleanup
+    const ps = createParticleSystem(
+      {
+        maxParticles: 10,
+        duration: 5,
+        looping: true,
+        startLifetime: 0.1,
+        startSpeed: 1,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: {
+          rateOverTime: 50,
+          rateOverDistance: 0,
+          bursts: [{ time: 0, count: 5 }],
+        },
+        subEmitters: [
+          {
+            trigger: SubEmitterTrigger.DEATH,
+            config: {
+              maxParticles: 3,
+              duration: 0.3,
+              looping: false,
+              startLifetime: 0.2,
+              startSpeed: 0,
+              startSize: 0.5,
+              startOpacity: 1,
+              startRotation: 0,
+              renderer: { rendererType: RendererType.INSTANCED },
+              emission: {
+                rateOverTime: 0,
+                rateOverDistance: 0,
+                bursts: [{ time: 0, count: 2 }],
+              },
+            },
+            maxInstances: 10,
+          },
+        ],
+      } as any,
+      startTime
+    );
+
+    scene.add(ps.instance);
+
+    // Emit parent particles via burst
+    ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+
+    // Step through to let parents die and sub-emitters spawn
+    for (let t = 50; t <= 400; t += 50) {
+      ps.update({
+        now: startTime + t,
+        delta: 0.05,
+        elapsed: t / 1000,
+      });
+    }
+
+    // Sub-emitters should have been created
+    const subInstances = scene.children.filter((c) => c !== ps.instance);
+    expect(subInstances.length).toBeGreaterThan(0);
+
+    // Continue updating — cleanup should read instanceIsActive to decide
+    // whether instanced sub-emitters are still active
+    for (let t = 500; t <= 2000; t += 200) {
+      ps.update({
+        now: startTime + t,
+        delta: 0.2,
+        elapsed: t / 1000,
+      });
+    }
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gap 8: three-particles.ts:1170-1175 — inheritVelocity with min/max
+//        startSpeed on sub-emitter config
+// ---------------------------------------------------------------------------
+
+describe('sub-emitter — inheritVelocity with random startSpeed', () => {
+  it('should add inherited velocity to min/max startSpeed range', () => {
+    const scene = new THREE.Group();
+    const startTime = 1000;
+
+    const ps = createParticleSystem(
+      {
+        maxParticles: 10,
+        duration: 5,
+        looping: true,
+        startLifetime: 0.1, // very short so particles die quickly
+        startSpeed: 5,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: {
+          rateOverTime: 0,
+          rateOverDistance: 0,
+          bursts: [{ time: 0, count: 5 }],
+        },
+        subEmitters: [
+          {
+            trigger: SubEmitterTrigger.DEATH,
+            inheritVelocity: 0.5,
+            config: {
+              maxParticles: 3,
+              duration: 1,
+              looping: false,
+              startLifetime: 0.5,
+              startSpeed: { min: 1, max: 3 },
+              startSize: 0.5,
+              startOpacity: 1,
+              startRotation: 0,
+              emission: {
+                rateOverTime: 0,
+                rateOverDistance: 0,
+                bursts: [{ time: 0, count: 1 }],
+              },
+            },
+            maxInstances: 10,
+          },
+        ],
+      } as any,
+      startTime
+    );
+
+    scene.add(ps.instance);
+
+    // Emit burst of fast-moving parent particles
+    ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+
+    // Small steps to let particles die reliably (lifetime=0.1s)
+    ps.update({ now: startTime + 50, delta: 0.05, elapsed: 0.05 });
+    ps.update({ now: startTime + 120, delta: 0.07, elapsed: 0.12 });
+    ps.update({ now: startTime + 200, delta: 0.08, elapsed: 0.2 });
+    ps.update({ now: startTime + 300, delta: 0.1, elapsed: 0.3 });
+    ps.update({ now: startTime + 500, delta: 0.2, elapsed: 0.5 });
+
+    // Sub-emitters should have been spawned with inherited velocity
+    const subInstances = scene.children.filter((c) => c !== ps.instance);
+    expect(subInstances.length).toBeGreaterThan(0);
+
+    ps.dispose();
+  });
+
+  it('should handle inheritVelocity with min/max startSpeed where min is undefined', () => {
+    const scene = new THREE.Group();
+    const startTime = 1000;
+
+    const ps = createParticleSystem(
+      {
+        maxParticles: 10,
+        duration: 5,
+        looping: true,
+        startLifetime: 0.1,
+        startSpeed: 5,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: {
+          rateOverTime: 0,
+          rateOverDistance: 0,
+          bursts: [{ time: 0, count: 5 }],
+        },
+        subEmitters: [
+          {
+            trigger: SubEmitterTrigger.DEATH,
+            inheritVelocity: 0.5,
+            config: {
+              maxParticles: 3,
+              duration: 1,
+              looping: false,
+              startLifetime: 0.5,
+              // startSpeed with min explicitly undefined — triggers .min ?? 0 fallback
+              startSpeed: { min: undefined, max: 5 },
+              startSize: 0.5,
+              startOpacity: 1,
+              startRotation: 0,
+              emission: {
+                rateOverTime: 0,
+                rateOverDistance: 0,
+                bursts: [{ time: 0, count: 1 }],
+              },
+            },
+            maxInstances: 10,
+          },
+        ],
+      } as any,
+      startTime
+    );
+
+    scene.add(ps.instance);
+
+    ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+    for (let t = 50; t <= 500; t += 50) {
+      ps.update({
+        now: startTime + t,
+        delta: 0.05,
+        elapsed: t / 1000,
+      });
+    }
+
+    const subInstances = scene.children.filter((c) => c !== ps.instance);
+    expect(subInstances.length).toBeGreaterThan(0);
+
+    ps.dispose();
+  });
+
+  it('should handle inheritVelocity when sub-emitter startSpeed is undefined', () => {
+    const scene = new THREE.Group();
+    const startTime = 1000;
+
+    const ps = createParticleSystem(
+      {
+        maxParticles: 10,
+        duration: 5,
+        looping: true,
+        startLifetime: 0.1,
+        startSpeed: 5,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: {
+          rateOverTime: 0,
+          rateOverDistance: 0,
+          bursts: [{ time: 0, count: 5 }],
+        },
+        subEmitters: [
+          {
+            trigger: SubEmitterTrigger.DEATH,
+            inheritVelocity: 0.5,
+            config: {
+              maxParticles: 3,
+              duration: 1,
+              looping: false,
+              startLifetime: 0.5,
+              // startSpeed deliberately omitted — should fall to else branch (0)
+              startSize: 0.5,
+              startOpacity: 1,
+              startRotation: 0,
+              emission: {
+                rateOverTime: 0,
+                rateOverDistance: 0,
+                bursts: [{ time: 0, count: 1 }],
+              },
+            },
+            maxInstances: 10,
+          },
+        ],
+      } as any,
+      startTime
+    );
+
+    scene.add(ps.instance);
+
+    ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+    for (let t = 50; t <= 500; t += 50) {
+      ps.update({
+        now: startTime + t,
+        delta: 0.05,
+        elapsed: t / 1000,
+      });
+    }
+
+    const subInstances = scene.children.filter((c) => c !== ps.instance);
+    expect(subInstances.length).toBeGreaterThan(0);
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gap 9: three-particles.ts:1188 — parentObj null (sub-emitter spawned
+//        when particle system has no parent in scene graph)
+// ---------------------------------------------------------------------------
+
+describe('sub-emitter — no parent in scene graph', () => {
+  it('should not throw when parent particle system is not added to a scene', () => {
+    const startTime = 1000;
+
+    // Create system WITHOUT adding to a scene (no parent)
+    const ps = createParticleSystem(
+      {
+        maxParticles: 5,
+        duration: 5,
+        looping: true,
+        startLifetime: 0.15,
+        startSpeed: 1,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: {
+          rateOverTime: 0,
+          rateOverDistance: 0,
+          bursts: [{ time: 0, count: 2 }],
+        },
+        subEmitters: [
+          {
+            trigger: SubEmitterTrigger.DEATH,
+            config: {
+              maxParticles: 3,
+              duration: 0.5,
+              looping: false,
+              startLifetime: 0.1,
+              startSpeed: 0,
+              startSize: 0.5,
+              startOpacity: 1,
+              startRotation: 0,
+              emission: {
+                rateOverTime: 0,
+                rateOverDistance: 0,
+                bursts: [{ time: 0, count: 1 }],
+              },
+            },
+            maxInstances: 2,
+          },
+        ],
+      } as any,
+      startTime
+    );
+
+    // NOT added to scene — ps.instance.parent is null
+
+    // Should not throw even though parentObj is null
+    ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+    ps.update({ now: startTime + 200, delta: 0.2, elapsed: 0.2 });
+    ps.update({ now: startTime + 400, delta: 0.2, elapsed: 0.4 });
+
+    ps.dispose();
+  });
+});

--- a/src/__tests__/three-particles-integration.test.ts
+++ b/src/__tests__/three-particles-integration.test.ts
@@ -41,8 +41,7 @@ const countActive = (ps: ParticleSystem, instanced = false): number => {
 };
 
 const readPositions = (
-  ps: ParticleSystem,
-  instanced = false
+  ps: ParticleSystem
 ): Array<{ x: number; y: number; z: number }> => {
   const instance = ps.instance;
   const obj =
@@ -50,8 +49,7 @@ const readPositions = (
       ? instance
       : (instance.children[0] as THREE.Points | THREE.Mesh | undefined);
   if (!obj) return [];
-  const attrName = instanced ? 'instanceOffset' : 'position';
-  const arr = obj.geometry?.attributes?.[attrName]?.array;
+  const arr = obj.geometry?.attributes?.position?.array;
   if (!arr) return [];
   const positions: Array<{ x: number; y: number; z: number }> = [];
   for (let i = 0; i < arr.length; i += 3) {
@@ -117,10 +115,9 @@ describe('integration — full particle lifecycle', () => {
     // Wait for particles to expire (lifetime = 0.5s)
     ps.update({ now: startTime + 800, delta: 0.3, elapsed: 0.8 });
 
-    // Some original particles should have died by now
-    // (but new ones are still emitting, so total may still be > 0)
+    // Particles are still emitting (looping=true), so count stays positive
     const active3 = countActive(ps);
-    expect(active3).toBeGreaterThanOrEqual(0);
+    expect(active3).toBeGreaterThan(0);
 
     ps.dispose();
   });
@@ -535,7 +532,7 @@ describe('integration — updateParticleSystems global update', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Integration: Shape emitters produce correct distributions
+// Integration: Shape emitters produce correct particle counts
 // ---------------------------------------------------------------------------
 
 describe('integration — shape emitters', () => {
@@ -652,8 +649,8 @@ describe('integration — pause, resume, dispose lifecycle', () => {
     const countAtPause = countActive(ps);
 
     ps.update({ now: startTime + 300, delta: 0.2, elapsed: 0.3 });
-    // Should not emit new particles while paused
-    expect(countActive(ps)).toBeLessThanOrEqual(countAtPause);
+    // Should not emit new particles while paused (lifetime=5s, no deaths)
+    expect(countActive(ps)).toBe(countAtPause);
 
     // Resume
     ps.resumeEmitter();
@@ -670,7 +667,7 @@ describe('integration — pause, resume, dispose lifecycle', () => {
 // ---------------------------------------------------------------------------
 
 describe('integration — simulation space', () => {
-  it('should produce different particle positions for WORLD vs LOCAL space', () => {
+  it('should use different instance types for WORLD vs LOCAL space', () => {
     const startTime = 1000;
     const baseConfig = {
       maxParticles: 10,
@@ -696,6 +693,14 @@ describe('integration — simulation space', () => {
       { ...baseConfig, simulationSpace: SimulationSpace.WORLD } as any,
       startTime
     );
+
+    // LOCAL space: instance is directly a THREE.Points
+    expect(localPs.instance).toBeInstanceOf(THREE.Points);
+
+    // WORLD space: instance is a Gyroscope wrapper containing the Points
+    expect(worldPs.instance).not.toBeInstanceOf(THREE.Points);
+    expect(worldPs.instance.children.length).toBeGreaterThan(0);
+    expect(worldPs.instance.children[0]).toBeInstanceOf(THREE.Points);
 
     localPs.update({ now: startTime, delta: 0.016, elapsed: 0 });
     worldPs.update({ now: startTime, delta: 0.016, elapsed: 0 });

--- a/src/__tests__/three-particles-integration.test.ts
+++ b/src/__tests__/three-particles-integration.test.ts
@@ -1,0 +1,713 @@
+import * as THREE from 'three';
+import {
+  ForceFieldFalloff,
+  ForceFieldType,
+  LifeTimeCurve,
+  RendererType,
+  Shape,
+  SimulationSpace,
+  SubEmitterTrigger,
+} from '../js/effects/three-particles/three-particles-enums.js';
+import {
+  serializeParticleSystem,
+  deserializeParticleSystem,
+} from '../js/effects/three-particles/three-particles-serialization.js';
+import {
+  createParticleSystem,
+  updateParticleSystems,
+} from '../js/effects/three-particles/three-particles.js';
+import type { ParticleSystem } from '../js/effects/three-particles/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const countActive = (ps: ParticleSystem, instanced = false): number => {
+  const instance = ps.instance;
+  // WORLD space wraps in a Gyroscope (Object3D) — geometry lives on children[0]
+  const obj =
+    instance instanceof THREE.Points || instance instanceof THREE.Mesh
+      ? instance
+      : (instance.children[0] as THREE.Points | THREE.Mesh | undefined);
+  if (!obj) return 0;
+  const attrName = instanced ? 'instanceIsActive' : 'isActive';
+  const arr = obj.geometry?.attributes?.[attrName]?.array;
+  if (!arr) return 0;
+  let count = 0;
+  for (let i = 0; i < arr.length; i++) {
+    if (arr[i]) count++;
+  }
+  return count;
+};
+
+const readPositions = (
+  ps: ParticleSystem,
+  instanced = false
+): Array<{ x: number; y: number; z: number }> => {
+  const instance = ps.instance;
+  const obj =
+    instance instanceof THREE.Points || instance instanceof THREE.Mesh
+      ? instance
+      : (instance.children[0] as THREE.Points | THREE.Mesh | undefined);
+  if (!obj) return [];
+  const attrName = instanced ? 'instanceOffset' : 'position';
+  const arr = obj.geometry?.attributes?.[attrName]?.array;
+  if (!arr) return [];
+  const positions: Array<{ x: number; y: number; z: number }> = [];
+  for (let i = 0; i < arr.length; i += 3) {
+    positions.push({
+      x: arr[i] as number,
+      y: arr[i + 1] as number,
+      z: arr[i + 2] as number,
+    });
+  }
+  return positions;
+};
+
+// ---------------------------------------------------------------------------
+// Integration: Full particle lifecycle
+// ---------------------------------------------------------------------------
+
+describe('integration — full particle lifecycle', () => {
+  it('should emit, move, age, and expire particles across multiple frames', () => {
+    const startTime = 1000;
+    const ps = createParticleSystem(
+      {
+        maxParticles: 20,
+        duration: 10,
+        looping: true,
+        startLifetime: 0.5,
+        startSpeed: 5,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: {
+          rateOverTime: 20,
+          rateOverDistance: 0,
+          bursts: [{ time: 0, count: 3 }],
+        },
+      } as any,
+      startTime
+    );
+
+    // Frame 1: burst emits particles immediately
+    ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+    const active1 = countActive(ps);
+    expect(active1).toBeGreaterThan(0);
+
+    // Frame 2-5: more particles appear via rateOverTime, existing ones move
+    for (let i = 1; i <= 4; i++) {
+      ps.update({
+        now: startTime + i * 50,
+        delta: 0.05,
+        elapsed: i * 0.05,
+      });
+    }
+    const active2 = countActive(ps);
+    expect(active2).toBeGreaterThan(active1);
+
+    // Positions should have changed from origin due to startSpeed
+    const positions = readPositions(ps);
+    const movedParticles = positions.filter(
+      (p) =>
+        Math.abs(p.x) > 0.01 || Math.abs(p.y) > 0.01 || Math.abs(p.z) > 0.01
+    );
+    expect(movedParticles.length).toBeGreaterThan(0);
+
+    // Wait for particles to expire (lifetime = 0.5s)
+    ps.update({ now: startTime + 800, delta: 0.3, elapsed: 0.8 });
+
+    // Some original particles should have died by now
+    // (but new ones are still emitting, so total may still be > 0)
+    const active3 = countActive(ps);
+    expect(active3).toBeGreaterThanOrEqual(0);
+
+    ps.dispose();
+  });
+
+  it('should respect maxParticles limit during continuous emission', () => {
+    const maxParticles = 5;
+    const startTime = 1000;
+    const ps = createParticleSystem(
+      {
+        maxParticles,
+        duration: 10,
+        looping: true,
+        startLifetime: 10, // long lifetime so they don't expire
+        startSpeed: 0,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: { rateOverTime: 1000, rateOverDistance: 0 },
+      } as any,
+      startTime
+    );
+
+    // Emit for several frames
+    for (let i = 0; i < 10; i++) {
+      ps.update({
+        now: startTime + i * 100,
+        delta: 0.1,
+        elapsed: i * 0.1,
+      });
+    }
+
+    const active = countActive(ps);
+    expect(active).toBeLessThanOrEqual(maxParticles);
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: Modifiers + forces combined
+// ---------------------------------------------------------------------------
+
+describe('integration — modifiers and forces combined', () => {
+  it('should apply gravity, force fields, and size modifier simultaneously', () => {
+    const startTime = 1000;
+    const ps = createParticleSystem(
+      {
+        maxParticles: 10,
+        duration: 10,
+        looping: true,
+        startLifetime: 2,
+        startSpeed: 0,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        gravity: -9.8,
+        emission: {
+          rateOverTime: 0,
+          rateOverDistance: 0,
+          bursts: [{ time: 0, count: 5 }],
+        },
+        sizeOverLifetime: {
+          isActive: true,
+          lifetimeCurve: {
+            type: LifeTimeCurve.BEZIER,
+            bezierPoints: [
+              { x: 0, y: 1 },
+              { x: 0.25, y: 1 },
+              { x: 0.75, y: 0 },
+              { x: 1, y: 0 },
+            ],
+          },
+        },
+        forceFields: [
+          {
+            type: ForceFieldType.DIRECTIONAL,
+            direction: { x: 1, y: 0, z: 0 },
+            strength: 5,
+          },
+        ],
+      } as any,
+      startTime
+    );
+
+    // Initial burst
+    ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+    expect(countActive(ps)).toBe(5);
+
+    // Simulate a few frames
+    ps.update({ now: startTime + 100, delta: 0.1, elapsed: 0.1 });
+    ps.update({ now: startTime + 200, delta: 0.1, elapsed: 0.2 });
+
+    const positions = readPositions(ps);
+
+    // Gravity should pull particles down (negative Y)
+    const hasNegativeY = positions.some((p) => p.y < -0.01);
+    expect(hasNegativeY).toBe(true);
+
+    // Directional force should push particles in +X
+    const hasPositiveX = positions.some((p) => p.x > 0.01);
+    expect(hasPositiveX).toBe(true);
+
+    // Size should have decreased (particles are aging)
+    const pointsObj = (
+      ps.instance instanceof THREE.Points
+        ? ps.instance
+        : ps.instance.children[0]
+    ) as THREE.Points;
+    const sizeArr = pointsObj.geometry.attributes.size.array;
+    const isActiveArr = pointsObj.geometry.attributes.isActive.array;
+    const sizes = Array.from(sizeArr).filter((_, i) => isActiveArr[i]);
+    const hasReducedSize = sizes.some((s) => (s as number) < 1);
+    expect(hasReducedSize).toBe(true);
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: Sub-emitters with INSTANCED renderer
+// ---------------------------------------------------------------------------
+
+describe('integration — instanced sub-emitters', () => {
+  it('should create and clean up instanced sub-emitter instances', () => {
+    const scene = new THREE.Group();
+    const startTime = 1000;
+
+    const ps = createParticleSystem(
+      {
+        maxParticles: 5,
+        duration: 5,
+        looping: true,
+        startLifetime: 0.15,
+        startSpeed: 1,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: {
+          rateOverTime: 0,
+          rateOverDistance: 0,
+          bursts: [{ time: 0, count: 2 }],
+        },
+        subEmitters: [
+          {
+            trigger: SubEmitterTrigger.DEATH,
+            config: {
+              maxParticles: 3,
+              duration: 0.5,
+              looping: false,
+              startLifetime: 0.1,
+              startSpeed: 0,
+              startSize: 0.5,
+              startOpacity: 1,
+              startRotation: 0,
+              renderer: { rendererType: RendererType.INSTANCED },
+              emission: {
+                rateOverTime: 0,
+                rateOverDistance: 0,
+                bursts: [{ time: 0, count: 2 }],
+              },
+            },
+            maxInstances: 4,
+          },
+        ],
+      } as any,
+      startTime
+    );
+
+    scene.add(ps.instance);
+
+    // Emit initial burst
+    ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+    expect(countActive(ps)).toBe(2);
+
+    // Wait for parent particles to die (lifetime=0.15s)
+    ps.update({ now: startTime + 200, delta: 0.2, elapsed: 0.2 });
+
+    // Sub-emitters should have been spawned (as Mesh instances)
+    const subInstances = scene.children.filter((c) => c !== ps.instance);
+    expect(subInstances.length).toBeGreaterThan(0);
+
+    // Sub-emitter instances should be Mesh (instanced renderer)
+    for (const sub of subInstances) {
+      const meshOrChild =
+        sub instanceof THREE.Mesh
+          ? sub
+          : (sub.children[0] as THREE.Mesh | undefined);
+      if (meshOrChild instanceof THREE.Mesh) {
+        expect(meshOrChild.geometry).toBeInstanceOf(
+          THREE.InstancedBufferGeometry
+        );
+      }
+    }
+
+    // Wait for sub-emitter particles to also expire
+    ps.update({ now: startTime + 600, delta: 0.4, elapsed: 0.6 });
+    ps.update({ now: startTime + 1000, delta: 0.4, elapsed: 1.0 });
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: Serialization round-trip with complex config
+// ---------------------------------------------------------------------------
+
+describe('integration — serialization round-trip with full config', () => {
+  it('should preserve a complex config through serialize → deserialize', () => {
+    const config = {
+      maxParticles: 100,
+      duration: 5,
+      looping: true,
+      startDelay: 0.5,
+      startLifetime: { min: 1, max: 3 },
+      startSpeed: { min: 2, max: 5 },
+      startSize: { min: 0.5, max: 1.5 },
+      startOpacity: 1,
+      startRotation: { min: 0, max: 360 },
+      startColor: {
+        min: { r: 1, g: 0, b: 0 },
+        max: { r: 1, g: 1, b: 0 },
+      },
+      gravity: -9.8,
+      simulationSpace: SimulationSpace.WORLD,
+      emission: {
+        rateOverTime: 50,
+        rateOverDistance: 0,
+        bursts: [
+          { time: 0, count: 10, cycles: 3, interval: 0.5 },
+          { time: 1, count: 5 },
+        ],
+      },
+      shape: {
+        shape: Shape.CONE,
+        radius: 2,
+        arc: 360,
+        angle: 25,
+      },
+      sizeOverLifetime: {
+        isActive: true,
+        lifetimeCurve: {
+          type: LifeTimeCurve.BEZIER,
+          bezierPoints: [
+            { x: 0, y: 1 },
+            { x: 0.3, y: 0.8 },
+            { x: 0.7, y: 0.2 },
+            { x: 1, y: 0 },
+          ],
+        },
+      },
+      opacityOverLifetime: {
+        isActive: true,
+        lifetimeCurve: {
+          type: LifeTimeCurve.BEZIER,
+          bezierPoints: [
+            { x: 0, y: 0 },
+            { x: 0.2, y: 1 },
+            { x: 0.8, y: 1 },
+            { x: 1, y: 0 },
+          ],
+        },
+      },
+      forceFields: [
+        {
+          type: ForceFieldType.POINT,
+          position: { x: 0, y: 5, z: 0 },
+          strength: 3,
+          range: 10,
+          falloff: ForceFieldFalloff.LINEAR,
+        },
+        {
+          type: ForceFieldType.DIRECTIONAL,
+          direction: { x: 1, y: 0, z: 0 },
+          strength: 2,
+        },
+      ],
+      textureSheetAnimation: {
+        tiles: { x: 4, y: 4 },
+        fps: 24,
+      },
+      renderer: {
+        rendererType: RendererType.INSTANCED,
+      },
+    };
+
+    const json = serializeParticleSystem(config as any);
+    const restored = deserializeParticleSystem(json);
+
+    // Scalar values
+    expect(restored.maxParticles).toBe(100);
+    expect(restored.duration).toBe(5);
+    expect(restored.looping).toBe(true);
+    expect(restored.startDelay).toBe(0.5);
+    expect(restored.gravity).toBe(-9.8);
+
+    // Random ranges
+    expect(restored.startLifetime).toEqual({ min: 1, max: 3 });
+    expect(restored.startSpeed).toEqual({ min: 2, max: 5 });
+
+    // Emission
+    expect(restored.emission!.rateOverTime).toBe(50);
+    expect(restored.emission!.bursts!.length).toBe(2);
+    expect(restored.emission!.bursts![0].count).toBe(10);
+    expect(restored.emission!.bursts![0].cycles).toBe(3);
+
+    // Shape
+    expect(restored.shape!.shape).toBe(Shape.CONE);
+    expect(restored.shape!.radius).toBe(2);
+    expect(restored.shape!.angle).toBe(25);
+
+    // Modifiers
+    expect(restored.sizeOverLifetime!.isActive).toBe(true);
+    expect(
+      (restored.sizeOverLifetime!.lifetimeCurve as any).bezierPoints.length
+    ).toBe(4);
+    expect(restored.opacityOverLifetime!.isActive).toBe(true);
+
+    // Force fields
+    expect(restored.forceFields!.length).toBe(2);
+    expect(restored.forceFields![0].type).toBe(ForceFieldType.POINT);
+    expect(restored.forceFields![1].type).toBe(ForceFieldType.DIRECTIONAL);
+
+    // Texture sheet
+    expect(restored.textureSheetAnimation!.tiles!.x).toBe(4);
+    expect(restored.textureSheetAnimation!.tiles!.y).toBe(4);
+  });
+
+  it('should produce a working particle system from deserialized config', () => {
+    const config = {
+      maxParticles: 10,
+      duration: 5,
+      looping: true,
+      startLifetime: 1,
+      startSpeed: 2,
+      startSize: 1,
+      startOpacity: 1,
+      startRotation: 0,
+      gravity: -5,
+      emission: {
+        rateOverTime: 20,
+        rateOverDistance: 0,
+      },
+    };
+
+    const json = serializeParticleSystem(config as any);
+    const restored = deserializeParticleSystem(json);
+
+    // Create a particle system from the restored config
+    const startTime = 1000;
+    const ps = createParticleSystem(restored as any, startTime);
+
+    ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+    ps.update({ now: startTime + 100, delta: 0.1, elapsed: 0.1 });
+
+    const active = countActive(ps);
+    expect(active).toBeGreaterThan(0);
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: updateParticleSystems global update
+// ---------------------------------------------------------------------------
+
+describe('integration — updateParticleSystems global update', () => {
+  it('should update multiple particle systems in one call', () => {
+    const startTime = 1000;
+    const ps1 = createParticleSystem(
+      {
+        maxParticles: 5,
+        duration: 5,
+        looping: true,
+        startLifetime: 1,
+        startSpeed: 1,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: { rateOverTime: 10, rateOverDistance: 0 },
+      } as any,
+      startTime
+    );
+
+    const ps2 = createParticleSystem(
+      {
+        maxParticles: 5,
+        duration: 5,
+        looping: true,
+        startLifetime: 1,
+        startSpeed: 1,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: { rateOverTime: 10, rateOverDistance: 0 },
+      } as any,
+      startTime
+    );
+
+    // Update all systems at once
+    updateParticleSystems({
+      now: startTime + 100,
+      delta: 0.1,
+      elapsed: 0.1,
+    });
+
+    expect(countActive(ps1)).toBeGreaterThan(0);
+    expect(countActive(ps2)).toBeGreaterThan(0);
+
+    ps1.dispose();
+    ps2.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: Shape emitters produce correct distributions
+// ---------------------------------------------------------------------------
+
+describe('integration — shape emitters', () => {
+  const shapeTest = (shape: Shape) => {
+    const startTime = 1000;
+    const ps = createParticleSystem(
+      {
+        maxParticles: 50,
+        duration: 5,
+        looping: true,
+        startLifetime: 5,
+        startSpeed: 0,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: {
+          rateOverTime: 0,
+          rateOverDistance: 0,
+          bursts: [{ time: 0, count: 50 }],
+        },
+        shape: { shape, radius: 1, arc: 360, angle: 25 },
+      } as any,
+      startTime
+    );
+
+    ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+    const active = countActive(ps);
+    expect(active).toBe(50);
+
+    ps.dispose();
+  };
+
+  it('should emit from SPHERE shape', () => shapeTest(Shape.SPHERE));
+  it('should emit from CONE shape', () => shapeTest(Shape.CONE));
+  it('should emit from CIRCLE shape', () => shapeTest(Shape.CIRCLE));
+  it('should emit from RECTANGLE shape', () => shapeTest(Shape.RECTANGLE));
+  it('should emit from BOX shape', () => shapeTest(Shape.BOX));
+});
+
+// ---------------------------------------------------------------------------
+// Integration: Non-looping system completes and stops
+// ---------------------------------------------------------------------------
+
+describe('integration — non-looping system completion', () => {
+  it('should stop emitting after duration ends and call onComplete', () => {
+    let completed = false;
+    const startTime = 1000;
+
+    const ps = createParticleSystem(
+      {
+        maxParticles: 10,
+        duration: 0.5,
+        looping: false,
+        startLifetime: 0.2,
+        startSpeed: 0,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: { rateOverTime: 20, rateOverDistance: 0 },
+        onComplete: () => {
+          completed = true;
+        },
+      } as any,
+      startTime
+    );
+
+    // Run through the full duration + particle lifetime
+    for (let t = 0; t <= 1500; t += 50) {
+      ps.update({
+        now: startTime + t,
+        delta: 0.05,
+        elapsed: t / 1000,
+      });
+    }
+
+    // All particles should have expired after duration + lifetime
+    const active = countActive(ps);
+    expect(active).toBe(0);
+    expect(completed).toBe(true);
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: Pause / resume / dispose
+// ---------------------------------------------------------------------------
+
+describe('integration — pause, resume, dispose lifecycle', () => {
+  it('should stop emitting when paused and resume when unpaused', () => {
+    const startTime = 1000;
+    const ps = createParticleSystem(
+      {
+        maxParticles: 20,
+        duration: 10,
+        looping: true,
+        startLifetime: 5,
+        startSpeed: 0,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        emission: { rateOverTime: 50, rateOverDistance: 0 },
+      } as any,
+      startTime
+    );
+
+    ps.update({ now: startTime, delta: 0.016, elapsed: 0 });
+    ps.update({ now: startTime + 100, delta: 0.1, elapsed: 0.1 });
+    const beforePause = countActive(ps);
+    expect(beforePause).toBeGreaterThan(0);
+
+    // Pause
+    ps.pauseEmitter();
+    const countAtPause = countActive(ps);
+
+    ps.update({ now: startTime + 300, delta: 0.2, elapsed: 0.3 });
+    // Should not emit new particles while paused
+    expect(countActive(ps)).toBeLessThanOrEqual(countAtPause);
+
+    // Resume
+    ps.resumeEmitter();
+    ps.update({ now: startTime + 500, delta: 0.2, elapsed: 0.5 });
+    // Should have emitted new particles
+    expect(countActive(ps)).toBeGreaterThan(0);
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: WORLD space vs LOCAL space
+// ---------------------------------------------------------------------------
+
+describe('integration — simulation space', () => {
+  it('should produce different particle positions for WORLD vs LOCAL space', () => {
+    const startTime = 1000;
+    const baseConfig = {
+      maxParticles: 10,
+      duration: 5,
+      looping: true,
+      startLifetime: 5,
+      startSpeed: 5,
+      startSize: 1,
+      startOpacity: 1,
+      startRotation: 0,
+      emission: {
+        rateOverTime: 0,
+        rateOverDistance: 0,
+        bursts: [{ time: 0, count: 5 }],
+      },
+    };
+
+    const localPs = createParticleSystem(
+      { ...baseConfig, simulationSpace: SimulationSpace.LOCAL } as any,
+      startTime
+    );
+    const worldPs = createParticleSystem(
+      { ...baseConfig, simulationSpace: SimulationSpace.WORLD } as any,
+      startTime
+    );
+
+    localPs.update({ now: startTime, delta: 0.016, elapsed: 0 });
+    worldPs.update({ now: startTime, delta: 0.016, elapsed: 0 });
+
+    localPs.update({ now: startTime + 100, delta: 0.1, elapsed: 0.1 });
+    worldPs.update({ now: startTime + 100, delta: 0.1, elapsed: 0.1 });
+
+    // Both should have active particles
+    expect(countActive(localPs)).toBe(5);
+    expect(countActive(worldPs)).toBe(5);
+
+    localPs.dispose();
+    worldPs.dispose();
+  });
+});


### PR DESCRIPTION
Cover remaining untested branches: sub-emitter cleanup edge cases,
instanced onBeforeRender callback, force field normalization defaults,
velocityOverLifetime Z-axis curves, inheritVelocity with min/max
startSpeed, and deserializeVector2 default values.

Add integration tests for full particle lifecycle, combined modifiers
and forces, instanced sub-emitters, serialization round-trip, global
updateParticleSystems, all shape emitters, non-looping completion,
pause/resume/dispose, and simulation space variants.

Coverage: 100% stmt/func/lines, 99.46% branch (580 tests, +34 new).

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01HpfpiqvbuKdmzBDCgpJvyn