### PR TITLE
feat: add updateConfig method for real-time parameter updates

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -138,7 +138,7 @@ Detailed guides are in `.claude/doc/` — read these on-demand, not loaded into 
 
 ## Project Status
 
-Completed: Core system, all shape emitters, lifetime modifiers, noise, burst/distance emission, texture sheet animation, world/local space, sub-emitters, force fields, GPU instancing, trail renderer (with smoothing, adaptive sampling, maxTime, twist prevention, connected ribbons), mesh renderer, soft particles, serialization, TypeDoc, visual editor, examples page, CI/CD, benchmark suite, React Three Fiber docs, llms.txt.
+Completed: Core system, all shape emitters, lifetime modifiers, noise, burst/distance emission, texture sheet animation, world/local space, sub-emitters, force fields, GPU instancing, trail renderer (with smoothing, adaptive sampling, maxTime, twist prevention, connected ribbons), mesh renderer, soft particles, serialization, TypeDoc, visual editor, examples page, CI/CD, benchmark suite, React Three Fiber docs, llms.txt, real-time config updates (`updateConfig`).
 
 **Planned:** Trail Phase 2 (UV texture modes, UV scrolling, width by speed), WebGPU compute, preset system.
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,18 @@ const effect = {
   // Your effect configuration here
   // It can be empty to use default settings
 };
-const { instance } = createParticleSystem(effect);
-scene.add(instance);
+const system = createParticleSystem(effect);
+scene.add(system.instance);
 
 // Update the particle system in your animation loop
 // Pass the current time, delta time, and elapsed time
 updateParticleSystems({now, delta, elapsed});
+
+// Update configuration at runtime without recreating the system
+system.updateConfig({
+  gravity: -9.8,
+  forceFields: [{ type: 'DIRECTIONAL', direction: { x: 1, y: 0, z: 0 }, strength: 5 }],
+});
 ```
 
 # Usage with React Three Fiber

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,6 +32,7 @@
 | Trail improvements (smoothing, adaptive sampling, maxTime, twist prevention, connected ribbons) | ✅ |
 | Mesh Particle Renderer (`RendererType.MESH`) | ✅ |
 | Soft Particles (depth-based fade near geometry) | ✅ |
+| Real-time config updates (`updateConfig`) | ✅ |
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -67,6 +67,7 @@ function animate() {
 | `resumeEmitter()` | `() => void` | Resume emitting particles |
 | `dispose()` | `() => void` | Destroy system, free resources |
 | `update(cycleData)` | `(CycleData) => void` | Update this system individually |
+| `updateConfig(config)` | `(Partial<ParticleSystemConfig>) => void` | Update configuration at runtime without recreating the system. System-level properties (gravity, force fields, noise, emission, color/size/opacity over lifetime) take effect immediately. Per-particle spawn properties (startColor, startSize, etc.) affect only newly emitted particles. |
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -50,6 +50,7 @@ function animate() {
 - `resumeEmitter()` — Resume particle emission
 - `dispose()` — Clean up and free resources
 - `update(cycleData)` — Update this specific system only
+- `updateConfig(config)` — Update configuration at runtime without recreating the system
 
 ## Key Configuration Properties
 

--- a/src/__tests__/three-particles-update-config-integration.test.ts
+++ b/src/__tests__/three-particles-update-config-integration.test.ts
@@ -168,7 +168,10 @@ describe('integration — updateConfig force field position effects', () => {
     let activeIdx = 0;
     for (let i = 0; i < isActiveArr.length; i++) {
       if (isActiveArr[i]) {
-        if (activeIdx < xBefore.length && posArr[i * 3] > xBefore[activeIdx] + 0.1) {
+        if (
+          activeIdx < xBefore.length &&
+          posArr[i * 3] > xBefore[activeIdx] + 0.1
+        ) {
           movedCount++;
         }
         activeIdx++;

--- a/src/__tests__/three-particles-update-config-integration.test.ts
+++ b/src/__tests__/three-particles-update-config-integration.test.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import {
   ForceFieldType,
+  Shape,
   SimulationSpace,
 } from '../js/effects/three-particles/three-particles-enums.js';
 import {
@@ -520,6 +521,261 @@ describe('integration — rapid successive updateConfig calls', () => {
 
     // System should still be functional
     expect(countActive(ps)).toBeGreaterThan(0);
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: updateConfig startColor verified with actual color values
+// ---------------------------------------------------------------------------
+
+describe('integration — updateConfig startColor with value verification', () => {
+  it('should spawn new particles with updated startColor after old ones expire', () => {
+    const { ps, step } = createTestSystem({
+      startLifetime: 0.2, // 200ms — particles die quickly
+      startColor: {
+        min: { r: 1, g: 1, b: 1 },
+        max: { r: 1, g: 1, b: 1 },
+      },
+    });
+
+    // Emit white particles
+    step(100);
+    const attrs = getAttributes(ps);
+    const isActiveArr = attrs.isActive.array;
+    const colorGArr = attrs.colorG.array as Float32Array;
+
+    // Verify all active particles are white (G=1)
+    for (let i = 0; i < isActiveArr.length; i++) {
+      if (isActiveArr[i]) {
+        expect(colorGArr[i]).toBeCloseTo(1, 1);
+      }
+    }
+
+    // Change to pure red (G=0)
+    ps.updateConfig({
+      startColor: {
+        min: { r: 1, g: 0, b: 0 },
+        max: { r: 1, g: 0, b: 0 },
+      },
+    });
+
+    // Wait for old particles to die (200ms lifetime) and new ones to spawn
+    step(500, 400);
+    step(800, 300);
+
+    // All active particles should now be red (G=0)
+    let allRed = true;
+    let activeCount = 0;
+    for (let i = 0; i < isActiveArr.length; i++) {
+      if (isActiveArr[i]) {
+        activeCount++;
+        if (colorGArr[i] > 0.01) allRed = false;
+      }
+    }
+    expect(activeCount).toBeGreaterThan(0);
+    expect(allRed).toBe(true);
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: updateConfig startSize verified with actual size values
+// ---------------------------------------------------------------------------
+
+describe('integration — updateConfig startSize with value verification', () => {
+  it('should spawn new particles with updated startSize', () => {
+    const { ps, step } = createTestSystem({
+      startLifetime: 0.2,
+      startSize: 1,
+    });
+
+    // Emit size-1 particles
+    step(100);
+    const attrs = getAttributes(ps);
+    const sizeArr = attrs.size.array as Float32Array;
+    const isActiveArr = attrs.isActive.array;
+
+    for (let i = 0; i < isActiveArr.length; i++) {
+      if (isActiveArr[i]) {
+        expect(sizeArr[i]).toBeCloseTo(1, 1);
+      }
+    }
+
+    // Change to size 5
+    ps.updateConfig({ startSize: 5 });
+
+    // Wait for old particles to die and new ones to spawn
+    step(500, 400);
+    step(800, 300);
+
+    let allLarge = true;
+    let activeCount = 0;
+    for (let i = 0; i < isActiveArr.length; i++) {
+      if (isActiveArr[i]) {
+        activeCount++;
+        if (sizeArr[i] < 4) allLarge = false;
+      }
+    }
+    expect(activeCount).toBeGreaterThan(0);
+    expect(allLarge).toBe(true);
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: updateConfig startSpeed verified with position spread
+// ---------------------------------------------------------------------------
+
+describe('integration — updateConfig startSpeed with position verification', () => {
+  it('should spawn faster particles after startSpeed increase', () => {
+    const { ps, step } = createTestSystem({
+      startLifetime: 1,
+      startSpeed: 0.1,
+      gravity: 0,
+    });
+
+    // Emit slow particles
+    step(100);
+    step(300, 200);
+
+    const attrs = getAttributes(ps);
+    const posArr = attrs.position.array as Float32Array;
+    const isActiveArr = attrs.isActive.array;
+
+    // Record max distance from origin for slow particles
+    let maxDistSlow = 0;
+    for (let i = 0; i < isActiveArr.length; i++) {
+      if (isActiveArr[i]) {
+        const px = posArr[i * 3],
+          py = posArr[i * 3 + 1],
+          pz = posArr[i * 3 + 2];
+        maxDistSlow = Math.max(
+          maxDistSlow,
+          Math.sqrt(px * px + py * py + pz * pz)
+        );
+      }
+    }
+
+    // Change to very fast particles
+    ps.updateConfig({ startSpeed: 50 });
+
+    // Emit fast particles
+    step(600, 300);
+    step(1000, 400);
+
+    let maxDistFast = 0;
+    for (let i = 0; i < isActiveArr.length; i++) {
+      if (isActiveArr[i]) {
+        const px = posArr[i * 3],
+          py = posArr[i * 3 + 1],
+          pz = posArr[i * 3 + 2];
+        maxDistFast = Math.max(
+          maxDistFast,
+          Math.sqrt(px * px + py * py + pz * pz)
+        );
+      }
+    }
+
+    expect(maxDistFast).toBeGreaterThan(maxDistSlow * 2);
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: updateConfig startLifetime verified
+// ---------------------------------------------------------------------------
+
+describe('integration — updateConfig startLifetime', () => {
+  it('should spawn particles with updated lifetime', () => {
+    const { ps, step } = createTestSystem({
+      startLifetime: 0.1, // very short: 100ms
+      emission: { rateOverTime: 50, rateOverDistance: 0 },
+    });
+
+    // Emit short-lived particles
+    step(50);
+    step(200, 150);
+    // After 200ms, all 100ms-lifetime particles should be dead except very recent
+    const countShort = countActive(ps);
+
+    // Change to long-lived particles
+    ps.updateConfig({ startLifetime: 10 });
+
+    // Emit long-lived particles
+    step(400, 200);
+    step(700, 300);
+    step(1200, 500);
+    const countLong = countActive(ps);
+
+    // With 10s lifetime, particles accumulate instead of dying
+    expect(countLong).toBeGreaterThan(countShort);
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: updateConfig shape change
+// ---------------------------------------------------------------------------
+
+describe('integration — updateConfig shape change', () => {
+  it('should use updated shape for new particles', () => {
+    const { ps, step } = createTestSystem({
+      startLifetime: 0.2,
+      startSpeed: 0,
+      gravity: 0,
+      shape: {
+        shape: Shape.SPHERE,
+        sphere: { radius: 0.01, radiusThickness: 1, arc: 360 },
+      },
+    });
+
+    // Emit particles from tiny sphere — all near origin
+    step(100);
+    const attrs = getAttributes(ps);
+    const posArr = attrs.position.array as Float32Array;
+    const isActiveArr = attrs.isActive.array;
+
+    let maxDist1 = 0;
+    for (let i = 0; i < isActiveArr.length; i++) {
+      if (isActiveArr[i]) {
+        const px = posArr[i * 3],
+          py = posArr[i * 3 + 1],
+          pz = posArr[i * 3 + 2];
+        maxDist1 = Math.max(maxDist1, Math.sqrt(px * px + py * py + pz * pz));
+      }
+    }
+    expect(maxDist1).toBeLessThan(0.1);
+
+    // Change to large sphere
+    ps.updateConfig({
+      shape: {
+        shape: Shape.SPHERE,
+        sphere: { radius: 10, radiusThickness: 1, arc: 360 },
+      },
+    });
+
+    // Wait for old particles to die and new ones to spawn from large sphere
+    step(500, 400);
+    step(800, 300);
+
+    let maxDist2 = 0;
+    for (let i = 0; i < isActiveArr.length; i++) {
+      if (isActiveArr[i]) {
+        const px = posArr[i * 3],
+          py = posArr[i * 3 + 1],
+          pz = posArr[i * 3 + 2];
+        maxDist2 = Math.max(maxDist2, Math.sqrt(px * px + py * py + pz * pz));
+      }
+    }
+
+    // New particles should be spread across a much larger area
+    expect(maxDist2).toBeGreaterThan(1);
 
     ps.dispose();
   });

--- a/src/__tests__/three-particles-update-config-integration.test.ts
+++ b/src/__tests__/three-particles-update-config-integration.test.ts
@@ -1,0 +1,526 @@
+import * as THREE from 'three';
+import {
+  ForceFieldType,
+  SimulationSpace,
+} from '../js/effects/three-particles/three-particles-enums.js';
+import {
+  createParticleSystem,
+  updateParticleSystems,
+} from '../js/effects/three-particles/three-particles.js';
+import type { ParticleSystem } from '../js/effects/three-particles/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const countActive = (ps: ParticleSystem): number => {
+  const instance = ps.instance;
+  const obj =
+    instance instanceof THREE.Points || instance instanceof THREE.Mesh
+      ? instance
+      : (instance.children[0] as THREE.Points | THREE.Mesh | undefined);
+  if (!obj) return 0;
+  const arr = obj.geometry?.attributes?.isActive?.array;
+  if (!arr) return 0;
+  let count = 0;
+  for (let i = 0; i < arr.length; i++) {
+    if (arr[i]) count++;
+  }
+  return count;
+};
+
+const getAttributes = (ps: ParticleSystem) => {
+  const instance = ps.instance;
+  const obj =
+    instance instanceof THREE.Points || instance instanceof THREE.Mesh
+      ? instance
+      : (instance.children[0] as THREE.Points | THREE.Mesh | undefined);
+  return obj!.geometry.attributes;
+};
+
+const createTestSystem = (
+  config: Record<string, unknown> = {},
+  startTime = 1000
+) => {
+  const ps = createParticleSystem(
+    {
+      maxParticles: 50,
+      duration: 10,
+      looping: true,
+      startLifetime: 2,
+      startSpeed: 1,
+      startSize: 1,
+      startOpacity: 1,
+      startRotation: 0,
+      emission: { rateOverTime: 20, rateOverDistance: 0 },
+      ...config,
+    } as any,
+    startTime
+  );
+
+  const step = (timeOffsetMs: number, deltaMs: number = 16) => {
+    ps.update({
+      now: startTime + timeOffsetMs,
+      delta: deltaMs / 1000,
+      elapsed: timeOffsetMs / 1000,
+    });
+  };
+
+  return { ps, step, startTime };
+};
+
+// ---------------------------------------------------------------------------
+// Integration: updateConfig with global updateParticleSystems
+// ---------------------------------------------------------------------------
+
+describe('integration — updateConfig with global updateParticleSystems', () => {
+  it('should apply config changes when updated via the global loop', () => {
+    const startTime = 1000;
+    const ps = createParticleSystem(
+      {
+        maxParticles: 30,
+        duration: 10,
+        looping: true,
+        startLifetime: 2,
+        startSpeed: 0,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        gravity: 0,
+        emission: { rateOverTime: 20, rateOverDistance: 0 },
+      } as any,
+      startTime
+    );
+
+    // Use global updater to emit particles
+    updateParticleSystems({ now: startTime + 100, delta: 0.1, elapsed: 0.1 });
+    const active1 = countActive(ps);
+    expect(active1).toBeGreaterThan(0);
+
+    // Update config to add gravity
+    ps.updateConfig({ gravity: -50 });
+
+    // Continue with global updater — gravity should apply
+    updateParticleSystems({ now: startTime + 300, delta: 0.2, elapsed: 0.3 });
+
+    // Verify particles have been affected by gravity (moved away from origin)
+    const attrs = getAttributes(ps);
+    const posArr = attrs.position.array as Float32Array;
+    let hasGravityEffect = false;
+    const isActiveArr = attrs.isActive.array;
+    for (let i = 0; i < isActiveArr.length; i++) {
+      if (isActiveArr[i] && Math.abs(posArr[i * 3 + 1]) > 1.5) {
+        hasGravityEffect = true;
+        break;
+      }
+    }
+    expect(hasGravityEffect).toBe(true);
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: updateConfig force field effect on particle positions
+// ---------------------------------------------------------------------------
+
+describe('integration — updateConfig force field position effects', () => {
+  it('should push particles in the force field direction after config update', () => {
+    const { ps, step } = createTestSystem({
+      startSpeed: 0, // particles stationary initially
+      gravity: 0,
+    });
+
+    // Emit particles
+    step(100);
+    const active = countActive(ps);
+    expect(active).toBeGreaterThan(0);
+
+    // Record positions before force field
+    const attrs = getAttributes(ps);
+    const posArr = attrs.position.array as Float32Array;
+    const isActiveArr = attrs.isActive.array;
+    const xBefore: number[] = [];
+    for (let i = 0; i < isActiveArr.length; i++) {
+      if (isActiveArr[i]) xBefore.push(posArr[i * 3]);
+    }
+
+    // Add a strong directional force field pushing +X
+    ps.updateConfig({
+      forceFields: [
+        {
+          isActive: true,
+          type: ForceFieldType.DIRECTIONAL,
+          direction: { x: 1, y: 0, z: 0 },
+          strength: 50,
+        },
+      ],
+    });
+
+    // Step forward several frames to let force accumulate
+    step(200, 100);
+    step(400, 200);
+    step(700, 300);
+
+    // Check that active particles have moved in +X direction
+    let movedCount = 0;
+    let activeIdx = 0;
+    for (let i = 0; i < isActiveArr.length; i++) {
+      if (isActiveArr[i]) {
+        if (activeIdx < xBefore.length && posArr[i * 3] > xBefore[activeIdx] + 0.1) {
+          movedCount++;
+        }
+        activeIdx++;
+      }
+    }
+    expect(movedCount).toBeGreaterThan(0);
+
+    ps.dispose();
+  });
+
+  it('should stop applying force after removing force fields', () => {
+    const { ps, step } = createTestSystem({
+      startSpeed: 0,
+      gravity: 0,
+      forceFields: [
+        {
+          isActive: true,
+          type: ForceFieldType.DIRECTIONAL,
+          direction: { x: 0, y: 1, z: 0 },
+          strength: 100,
+        },
+      ],
+    });
+
+    // Emit and let force field accelerate particles
+    step(100);
+    step(300, 200);
+
+    const attrs = getAttributes(ps);
+    const posArr = attrs.position.array as Float32Array;
+    const isActiveArr = attrs.isActive.array;
+
+    // Record Y velocities (approximated by Y positions)
+    const yBefore: number[] = [];
+    for (let i = 0; i < isActiveArr.length; i++) {
+      if (isActiveArr[i]) yBefore.push(posArr[i * 3 + 1]);
+    }
+
+    // Remove force fields
+    ps.updateConfig({ forceFields: [] });
+
+    // Step forward — particles still move (inertia) but no additional acceleration
+    step(400, 100);
+    step(500, 100);
+
+    // Particles should still be alive and system should be stable
+    expect(countActive(ps)).toBeGreaterThan(0);
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: updateConfig color changes affect new particles only
+// ---------------------------------------------------------------------------
+
+describe('integration — updateConfig color changes on new particles', () => {
+  it('should emit new particles with updated startColor', () => {
+    const { ps, step } = createTestSystem({
+      startLifetime: 0.3, // short lifetime so old particles die
+      startColor: {
+        min: { r: 1, g: 1, b: 1 },
+        max: { r: 1, g: 1, b: 1 },
+      },
+    });
+
+    // Emit white particles
+    step(100);
+    const attrs = getAttributes(ps);
+    const colorRArr = attrs.colorR.array as Float32Array;
+    const colorGArr = attrs.colorG.array as Float32Array;
+    const isActiveArr = attrs.isActive.array;
+
+    // Verify initial particles are white (R=1, G=1)
+    for (let i = 0; i < isActiveArr.length; i++) {
+      if (isActiveArr[i]) {
+        expect(colorRArr[i]).toBeCloseTo(1, 1);
+        expect(colorGArr[i]).toBeCloseTo(1, 1);
+      }
+    }
+
+    // Change color to red
+    ps.updateConfig({
+      startColor: {
+        min: { r: 1, g: 0, b: 0 },
+        max: { r: 1, g: 0, b: 0 },
+      },
+    });
+
+    // Wait for old particles to die, new ones to spawn with red
+    step(600, 500);
+    step(900, 300);
+
+    // Check that newly spawned particles are red (R=1, G=0)
+    let hasRedParticle = false;
+    for (let i = 0; i < isActiveArr.length; i++) {
+      if (isActiveArr[i]) {
+        if (colorRArr[i] > 0.9 && colorGArr[i] < 0.1) {
+          hasRedParticle = true;
+          break;
+        }
+      }
+    }
+    expect(hasRedParticle).toBe(true);
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: multiple systems with independent updateConfig
+// ---------------------------------------------------------------------------
+
+describe('integration — multiple systems with independent config updates', () => {
+  it('should update configs independently for each system', () => {
+    const startTime = 1000;
+    const ps1 = createParticleSystem(
+      {
+        maxParticles: 20,
+        duration: 10,
+        looping: true,
+        startLifetime: 2,
+        startSpeed: 0,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        gravity: 0,
+        emission: { rateOverTime: 20, rateOverDistance: 0 },
+      } as any,
+      startTime
+    );
+    const ps2 = createParticleSystem(
+      {
+        maxParticles: 20,
+        duration: 10,
+        looping: true,
+        startLifetime: 2,
+        startSpeed: 0,
+        startSize: 1,
+        startOpacity: 1,
+        startRotation: 0,
+        gravity: 0,
+        emission: { rateOverTime: 20, rateOverDistance: 0 },
+      } as any,
+      startTime
+    );
+
+    // Emit particles in both systems via global updater
+    updateParticleSystems({ now: startTime + 100, delta: 0.1, elapsed: 0.1 });
+    expect(countActive(ps1)).toBeGreaterThan(0);
+    expect(countActive(ps2)).toBeGreaterThan(0);
+
+    // Update only ps1 with downward gravity
+    ps1.updateConfig({ gravity: -100 });
+    // ps2 stays at gravity: 0
+
+    // Step both via global updater
+    updateParticleSystems({ now: startTime + 400, delta: 0.3, elapsed: 0.4 });
+
+    const attrs1 = getAttributes(ps1);
+    const posArr1 = attrs1.position.array as Float32Array;
+    const isActive1 = attrs1.isActive.array;
+
+    const attrs2 = getAttributes(ps2);
+    const posArr2 = attrs2.position.array as Float32Array;
+    const isActive2 = attrs2.isActive.array;
+
+    // ps1 particles should have moved down significantly
+    let ps1MinY = Infinity;
+    for (let i = 0; i < isActive1.length; i++) {
+      if (isActive1[i]) ps1MinY = Math.min(ps1MinY, posArr1[i * 3 + 1]);
+    }
+
+    // ps2 particles should stay near origin (no gravity, no speed) — sphere emitter radius is 1
+    let ps2MaxAbsY = 0;
+    for (let i = 0; i < isActive2.length; i++) {
+      if (isActive2[i])
+        ps2MaxAbsY = Math.max(ps2MaxAbsY, Math.abs(posArr2[i * 3 + 1]));
+    }
+
+    expect(ps1MinY).toBeLessThan(-0.1);
+    expect(ps2MaxAbsY).toBeLessThan(1.5); // within sphere radius + tolerance
+
+    ps1.dispose();
+    ps2.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: updateConfig gravity with position verification
+// ---------------------------------------------------------------------------
+
+describe('integration — updateConfig gravity verification', () => {
+  it('should produce different Y positions with and without gravity', () => {
+    // System A: no gravity
+    const startTime = 1000;
+    const baseConfig = {
+      maxParticles: 20,
+      duration: 10,
+      looping: true,
+      startLifetime: 5,
+      startSpeed: 0,
+      startSize: 1,
+      startOpacity: 1,
+      startRotation: 0,
+      gravity: 0,
+      emission: { rateOverTime: 50, rateOverDistance: 0 },
+    } as any;
+
+    const psNoGravity = createParticleSystem(baseConfig, startTime);
+    const psWithGravity = createParticleSystem(baseConfig, startTime);
+
+    // Emit particles in both
+    const frame1 = { now: startTime + 100, delta: 0.1, elapsed: 0.1 };
+    psNoGravity.update(frame1);
+    psWithGravity.update(frame1);
+
+    // Now enable gravity on one
+    psWithGravity.updateConfig({ gravity: -50 });
+
+    // Step both forward with same timing
+    for (let t = 200; t <= 1000; t += 100) {
+      const frame = { now: startTime + t, delta: 0.1, elapsed: t / 1000 };
+      psNoGravity.update(frame);
+      psWithGravity.update(frame);
+    }
+
+    // Compare: gravity system particles should have moved differently from no-gravity
+    const getMaxAbsY = (ps: ParticleSystem) => {
+      const a = getAttributes(ps);
+      const pos = a.position.array as Float32Array;
+      const isAct = a.isActive.array;
+      let maxAbsY = 0;
+      for (let i = 0; i < isAct.length; i++) {
+        if (isAct[i]) maxAbsY = Math.max(maxAbsY, Math.abs(pos[i * 3 + 1]));
+      }
+      return maxAbsY;
+    };
+
+    // With gravity=-50 and startSpeed=0, particles should be pushed away from origin
+    // more than the no-gravity particles (which only have sphere position offsets)
+    expect(getMaxAbsY(psWithGravity)).toBeGreaterThan(getMaxAbsY(psNoGravity));
+
+    psNoGravity.dispose();
+    psWithGravity.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: updateConfig emission + lifecycle
+// ---------------------------------------------------------------------------
+
+describe('integration — updateConfig emission rate lifecycle', () => {
+  it('should ramp up and down emission rate during system lifetime', () => {
+    const { ps, step } = createTestSystem({
+      emission: { rateOverTime: 5, rateOverDistance: 0 },
+      startLifetime: 0.5,
+    });
+
+    // Low emission rate — emit a few particles
+    step(200);
+    step(500, 300);
+    const countLow = countActive(ps);
+
+    // Ramp up emission
+    ps.updateConfig({
+      emission: { rateOverTime: 200, rateOverDistance: 0 },
+    });
+
+    step(800, 300);
+    step(1200, 400);
+    const countHigh = countActive(ps);
+    expect(countHigh).toBeGreaterThan(countLow);
+
+    // Ramp down emission back to zero
+    ps.updateConfig({
+      emission: { rateOverTime: 0, rateOverDistance: 0 },
+    });
+
+    // Wait for existing particles to die (lifetime 0.5s = 500ms)
+    step(2000, 800);
+    step(2500, 500);
+    const countAfterStop = countActive(ps);
+    expect(countAfterStop).toBeLessThan(countHigh);
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: updateConfig with simulationSpace
+// ---------------------------------------------------------------------------
+
+describe('integration — updateConfig simulationSpace', () => {
+  it('should switch simulation space at runtime without crashing', () => {
+    const { ps, step } = createTestSystem({
+      simulationSpace: SimulationSpace.LOCAL,
+    });
+
+    step(100);
+    expect(countActive(ps)).toBeGreaterThan(0);
+
+    // Switch to world space
+    ps.updateConfig({ simulationSpace: SimulationSpace.WORLD });
+
+    // Continue stepping — should not throw
+    step(200, 100);
+    step(400, 200);
+    expect(countActive(ps)).toBeGreaterThan(0);
+
+    // Switch back
+    ps.updateConfig({ simulationSpace: SimulationSpace.LOCAL });
+    step(600, 200);
+    expect(countActive(ps)).toBeGreaterThan(0);
+
+    ps.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: rapid successive updateConfig calls (stress)
+// ---------------------------------------------------------------------------
+
+describe('integration — rapid successive updateConfig calls', () => {
+  it('should handle many config changes between frames without corruption', () => {
+    const { ps, step } = createTestSystem({
+      gravity: 0,
+      startSpeed: 1,
+    });
+
+    step(100);
+    expect(countActive(ps)).toBeGreaterThan(0);
+
+    // Rapidly change config many times before the next frame
+    for (let i = 0; i < 20; i++) {
+      ps.updateConfig({ gravity: -i * 2 });
+      ps.updateConfig({
+        forceFields: [
+          {
+            type: ForceFieldType.DIRECTIONAL,
+            direction: { x: Math.sin(i), y: Math.cos(i), z: 0 },
+            strength: i,
+          },
+        ],
+      });
+    }
+
+    // Step — the last config should be active
+    step(200, 100);
+    step(400, 200);
+
+    // System should still be functional
+    expect(countActive(ps)).toBeGreaterThan(0);
+
+    ps.dispose();
+  });
+});

--- a/src/__tests__/three-particles-update-config.test.ts
+++ b/src/__tests__/three-particles-update-config.test.ts
@@ -1,0 +1,362 @@
+import * as THREE from 'three';
+import {
+  ForceFieldType,
+  ForceFieldFalloff,
+} from '../js/effects/three-particles/three-particles-enums.js';
+import { createParticleSystem } from '../js/effects/three-particles/three-particles.js';
+import { ParticleSystem } from '../js/effects/three-particles/types.js';
+
+/**
+ * Helper: count active particles by reading the isActive buffer attribute.
+ */
+const countActiveParticles = (ps: ParticleSystem): number => {
+  const points = ps.instance as THREE.Points;
+  const isActiveArr = points.geometry.attributes.isActive.array;
+  let count = 0;
+  for (let i = 0; i < isActiveArr.length; i++) {
+    if (isActiveArr[i]) count++;
+  }
+  return count;
+};
+
+/**
+ * Helper: get geometry attributes from particle system.
+ */
+const getAttributes = (ps: ParticleSystem) => {
+  const points = ps.instance as THREE.Points;
+  return points.geometry.attributes;
+};
+
+/**
+ * Helper: create system and step function.
+ */
+const createTestSystem = (
+  config: Record<string, unknown> = {},
+  startTime = 1000
+) => {
+  const ps = createParticleSystem(
+    {
+      maxParticles: 50,
+      duration: 5,
+      looping: true,
+      startLifetime: 2,
+      startSpeed: 1,
+      startSize: 1,
+      startOpacity: 1,
+      startRotation: 0,
+      emission: { rateOverTime: 10, rateOverDistance: 0 },
+      ...config,
+    } as any,
+    startTime
+  );
+
+  const step = (timeOffsetMs: number, deltaMs: number = 16) => {
+    ps.update({
+      now: startTime + timeOffsetMs,
+      delta: deltaMs / 1000,
+      elapsed: timeOffsetMs / 1000,
+    });
+  };
+
+  return { ps, step, startTime };
+};
+
+describe('ParticleSystem.updateConfig', () => {
+  it('should be a function on the returned particle system', () => {
+    const { ps } = createTestSystem();
+    expect(typeof ps.updateConfig).toBe('function');
+    ps.dispose();
+  });
+
+  describe('gravity updates', () => {
+    it('should update gravity in real time', () => {
+      const { ps, step } = createTestSystem({ gravity: 0 });
+
+      // Emit some particles
+      step(100);
+      const active = countActiveParticles(ps);
+      expect(active).toBeGreaterThan(0);
+
+      // Record Y positions before gravity change
+      const attrs = getAttributes(ps);
+      const posArr = attrs.position.array as Float32Array;
+      const yBefore = posArr[1]; // first particle Y
+
+      // Change gravity
+      ps.updateConfig({ gravity: -9.8 });
+
+      // Step forward - gravity should now affect particles
+      step(200, 100);
+      step(500, 300);
+
+      // The system should continue working without errors
+      expect(countActiveParticles(ps)).toBeGreaterThan(0);
+      ps.dispose();
+    });
+  });
+
+  describe('force field updates', () => {
+    it('should replace force fields at runtime', () => {
+      const { ps, step } = createTestSystem();
+
+      // Emit particles with no force fields
+      step(100);
+      expect(countActiveParticles(ps)).toBeGreaterThan(0);
+
+      // Add a directional force field
+      ps.updateConfig({
+        forceFields: [
+          {
+            isActive: true,
+            type: ForceFieldType.DIRECTIONAL,
+            direction: { x: 1, y: 0, z: 0 },
+            strength: 10,
+          },
+        ],
+      });
+
+      // Step forward - should not throw
+      step(200, 100);
+      expect(countActiveParticles(ps)).toBeGreaterThan(0);
+      ps.dispose();
+    });
+
+    it('should allow removing all force fields', () => {
+      const { ps, step } = createTestSystem({
+        forceFields: [
+          {
+            isActive: true,
+            type: ForceFieldType.DIRECTIONAL,
+            direction: { x: 1, y: 0, z: 0 },
+            strength: 5,
+          },
+        ],
+      });
+
+      step(100);
+      expect(countActiveParticles(ps)).toBeGreaterThan(0);
+
+      // Remove force fields
+      ps.updateConfig({ forceFields: [] });
+
+      // Should continue without errors
+      step(200, 100);
+      expect(countActiveParticles(ps)).toBeGreaterThan(0);
+      ps.dispose();
+    });
+  });
+
+  describe('emission rate updates', () => {
+    it('should change emission rate at runtime', () => {
+      const { ps, step } = createTestSystem({
+        emission: { rateOverTime: 5, rateOverDistance: 0 },
+      });
+
+      step(500);
+      const countLow = countActiveParticles(ps);
+
+      // Increase emission rate dramatically
+      ps.updateConfig({
+        emission: { rateOverTime: 100, rateOverDistance: 0 },
+      });
+
+      step(1000, 500);
+      const countHigh = countActiveParticles(ps);
+
+      // With higher emission rate we should get more particles
+      expect(countHigh).toBeGreaterThan(countLow);
+      ps.dispose();
+    });
+  });
+
+  describe('noise updates', () => {
+    it('should enable noise at runtime', () => {
+      const { ps, step } = createTestSystem({
+        noise: {
+          isActive: false,
+          strength: 1,
+          frequency: 1,
+          octaves: 1,
+          positionAmount: 1,
+          rotationAmount: 0,
+          sizeAmount: 0,
+          useRandomOffset: false,
+        },
+      });
+
+      step(100);
+      expect(countActiveParticles(ps)).toBeGreaterThan(0);
+
+      // Enable noise
+      ps.updateConfig({
+        noise: {
+          isActive: true,
+          strength: 2,
+          frequency: 0.5,
+          octaves: 2,
+          positionAmount: 1,
+          rotationAmount: 0,
+          sizeAmount: 0,
+          useRandomOffset: false,
+        },
+      });
+
+      // Should not throw
+      step(200, 100);
+      expect(countActiveParticles(ps)).toBeGreaterThan(0);
+      ps.dispose();
+    });
+
+    it('should disable noise at runtime', () => {
+      const { ps, step } = createTestSystem({
+        noise: {
+          isActive: true,
+          strength: 1,
+          frequency: 1,
+          octaves: 1,
+          positionAmount: 1,
+          rotationAmount: 0,
+          sizeAmount: 0,
+          useRandomOffset: false,
+        },
+      });
+
+      step(100);
+
+      ps.updateConfig({
+        noise: {
+          isActive: false,
+          strength: 0,
+          frequency: 1,
+          octaves: 1,
+          positionAmount: 0,
+          rotationAmount: 0,
+          sizeAmount: 0,
+          useRandomOffset: false,
+        },
+      });
+
+      step(200, 100);
+      expect(countActiveParticles(ps)).toBeGreaterThan(0);
+      ps.dispose();
+    });
+  });
+
+  describe('duration and looping updates', () => {
+    it('should update duration', () => {
+      const { ps } = createTestSystem({ duration: 5 });
+
+      ps.updateConfig({ duration: 10 });
+
+      // Should not throw and system keeps running
+      ps.update({ now: 6000, delta: 0.016, elapsed: 5 });
+      ps.dispose();
+    });
+
+    it('should update looping', () => {
+      const { ps } = createTestSystem({ looping: true });
+
+      ps.updateConfig({ looping: false });
+
+      // Should not throw
+      ps.update({ now: 6000, delta: 0.016, elapsed: 5 });
+      ps.dispose();
+    });
+  });
+
+  describe('color and size config updates', () => {
+    it('should update startColor for new particles', () => {
+      const { ps, step } = createTestSystem({
+        startColor: {
+          min: { r: 1, g: 1, b: 1 },
+          max: { r: 1, g: 1, b: 1 },
+        },
+      });
+
+      step(100);
+
+      // Change start color to red
+      ps.updateConfig({
+        startColor: {
+          min: { r: 1, g: 0, b: 0 },
+          max: { r: 1, g: 0, b: 0 },
+        },
+      });
+
+      // Step to emit new particles with the new color
+      step(500, 400);
+
+      // System should work without errors
+      expect(countActiveParticles(ps)).toBeGreaterThan(0);
+      ps.dispose();
+    });
+
+    it('should update startSize for new particles', () => {
+      const { ps, step } = createTestSystem({ startSize: 1 });
+
+      step(100);
+
+      ps.updateConfig({ startSize: 5 });
+
+      step(500, 400);
+      expect(countActiveParticles(ps)).toBeGreaterThan(0);
+      ps.dispose();
+    });
+  });
+
+  describe('multiple sequential updates', () => {
+    it('should handle multiple updateConfig calls', () => {
+      const { ps, step } = createTestSystem();
+
+      step(100);
+
+      // First update
+      ps.updateConfig({ gravity: -5 });
+      step(200, 100);
+
+      // Second update
+      ps.updateConfig({
+        gravity: -10,
+        forceFields: [
+          {
+            type: ForceFieldType.POINT,
+            position: { x: 0, y: 5, z: 0 },
+            strength: 3,
+            range: 10,
+          },
+        ],
+      });
+      step(300, 100);
+
+      // Third update - remove force fields and change emission
+      ps.updateConfig({
+        forceFields: [],
+        emission: { rateOverTime: 50, rateOverDistance: 0 },
+      });
+      step(400, 100);
+
+      expect(countActiveParticles(ps)).toBeGreaterThan(0);
+      ps.dispose();
+    });
+  });
+
+  describe('partial config merging', () => {
+    it('should only update specified properties', () => {
+      const { ps, step } = createTestSystem({
+        gravity: -5,
+        duration: 10,
+      });
+
+      step(100);
+
+      // Only update gravity, duration should remain 10
+      ps.updateConfig({ gravity: -20 });
+
+      step(200, 100);
+
+      // System should still work (not crash due to missing config)
+      expect(countActiveParticles(ps)).toBeGreaterThan(0);
+      ps.dispose();
+    });
+  });
+});

--- a/src/js/effects/three-particles/three-particles.ts
+++ b/src/js/effects/three-particles/three-particles.ts
@@ -1147,14 +1147,14 @@ export const createParticleSystem = (
     generalData.startValues.startColorB[particleIndex] =
       aColorB.array[particleIndex];
 
-    aStartFrame.array[particleIndex] =
-      normalizedConfig.textureSheetAnimation.startFrame
-        ? calculateValue(
-            generalData.particleSystemId,
-            normalizedConfig.textureSheetAnimation.startFrame,
-            0
-          )
-        : 0;
+    aStartFrame.array[particleIndex] = normalizedConfig.textureSheetAnimation
+      .startFrame
+      ? calculateValue(
+          generalData.particleSystemId,
+          normalizedConfig.textureSheetAnimation.startFrame,
+          0
+        )
+      : 0;
     aStartFrame.needsUpdate = true;
 
     aStartLifetime.array[particleIndex] =
@@ -1788,8 +1788,8 @@ export const createParticleSystem = (
             })
           : undefined,
         offsets: n.useRandomOffset
-          ? generalData.noise.offsets ??
-            Array.from({ length: maxParticles }, () => Math.random() * 100)
+          ? (generalData.noise.offsets ??
+            Array.from({ length: maxParticles }, () => Math.random() * 100))
           : undefined,
       };
     }

--- a/src/js/effects/three-particles/three-particles.ts
+++ b/src/js/effects/three-particles/three-particles.ts
@@ -94,6 +94,31 @@ const _modifierParams = {
 };
 
 /**
+ * Converts a plain {x, y, z} object to a THREE.Vector3, using the fallback if undefined.
+ */
+const toVector3 = (
+  v: { x?: number; y?: number; z?: number } | undefined,
+  fallback: THREE.Vector3
+): THREE.Vector3 =>
+  v ? new THREE.Vector3(v.x ?? 0, v.y ?? 0, v.z ?? 0) : fallback.clone();
+
+/**
+ * Normalizes raw force field configs into the internal representation with THREE.Vector3 fields.
+ */
+const normalizeForceFields = (
+  rawForceFields: Array<ForceFieldConfig> | undefined
+): Array<NormalizedForceFieldConfig> =>
+  (rawForceFields ?? []).map((ff: ForceFieldConfig) => ({
+    isActive: ff.isActive ?? true,
+    type: ff.type ?? ForceFieldType.POINT,
+    position: toVector3(ff.position, new THREE.Vector3(0, 0, 0)),
+    direction: toVector3(ff.direction, new THREE.Vector3(0, 1, 0)).normalize(),
+    strength: ff.strength ?? 1,
+    range: Math.max(0, ff.range ?? Infinity),
+    falloff: ff.falloff ?? ForceFieldFalloff.LINEAR,
+  }));
+
+/**
  * Mapping of blending mode string identifiers to Three.js blending constants.
  *
  * Used for converting serialized particle system configurations (e.g., from JSON)
@@ -552,22 +577,8 @@ export const createParticleSystem = (
     forceFields: rawForceFields,
   } = normalizedConfig;
 
-  const toVector3 = (
-    v: { x?: number; y?: number; z?: number } | undefined,
-    fallback: THREE.Vector3
-  ) => (v ? new THREE.Vector3(v.x ?? 0, v.y ?? 0, v.z ?? 0) : fallback.clone());
-
-  const normalizedForceFields: Array<NormalizedForceFieldConfig> = (
-    rawForceFields ?? []
-  ).map((ff: ForceFieldConfig) => ({
-    isActive: ff.isActive ?? true,
-    type: ff.type ?? ForceFieldType.POINT,
-    position: toVector3(ff.position, new THREE.Vector3(0, 0, 0)),
-    direction: toVector3(ff.direction, new THREE.Vector3(0, 1, 0)).normalize(),
-    strength: ff.strength ?? 1,
-    range: Math.max(0, ff.range ?? Infinity),
-    falloff: ff.falloff ?? ForceFieldFalloff.LINEAR,
-  }));
+  const normalizedForceFields: Array<NormalizedForceFieldConfig> =
+    normalizeForceFields(rawForceFields);
 
   if (typeof renderer?.blending === 'string')
     renderer.blending = blendingMap[renderer.blending];
@@ -1727,12 +1738,68 @@ export const createParticleSystem = (
     }
   };
 
+  const updateConfig = (partialConfig: Partial<ParticleSystemConfig>) => {
+    // Deep-merge partial config into the live normalizedConfig
+    ObjectUtils.deepMerge(instanceData.normalizedConfig, partialConfig, {
+      applyToFirstObject: true,
+      skippedProperties: [],
+    });
+
+    const cfg = instanceData.normalizedConfig;
+
+    // Update instance-level cached scalars
+    if (partialConfig.gravity !== undefined) {
+      instanceData.gravity = cfg.gravity;
+      // Force gravityVelocity recalculation on next frame
+      generalData.lastWorldQuaternion.x = -99999;
+    }
+    if (partialConfig.duration !== undefined)
+      instanceData.duration = cfg.duration;
+    if (partialConfig.looping !== undefined) instanceData.looping = cfg.looping;
+    if (partialConfig.simulationSpace !== undefined)
+      instanceData.simulationSpace = cfg.simulationSpace;
+    if (partialConfig.emission !== undefined)
+      instanceData.emission = cfg.emission;
+
+    // Re-normalize force fields when changed
+    if (partialConfig.forceFields !== undefined) {
+      instanceData.normalizedForceFields = normalizeForceFields(
+        cfg.forceFields
+      );
+    }
+
+    // Re-initialize noise when changed
+    if (partialConfig.noise !== undefined) {
+      const n = cfg.noise;
+      generalData.noise = {
+        isActive: n.isActive,
+        strength: n.strength,
+        noisePower: 0.15 * n.strength,
+        positionAmount: n.positionAmount,
+        rotationAmount: n.rotationAmount,
+        sizeAmount: n.sizeAmount,
+        sampler: n.isActive
+          ? new FBM({
+              seed: Math.random(),
+              scale: n.frequency,
+              octaves: n.octaves,
+            })
+          : undefined,
+        offsets: n.useRandomOffset
+          ? generalData.noise.offsets ??
+            Array.from({ length: maxParticles }, () => Math.random() * 100)
+          : undefined,
+      };
+    }
+  };
+
   return {
     instance: wrapper || particleSystem,
     resumeEmitter,
     pauseEmitter,
     dispose,
     update,
+    updateConfig,
   };
 };
 

--- a/src/js/effects/three-particles/three-particles.ts
+++ b/src/js/effects/three-particles/three-particles.ts
@@ -1123,20 +1123,21 @@ export const createParticleSystem = (
       generalData.noise.offsets[particleIndex] = Math.random() * 100;
 
     const colorRandomRatio = Math.random();
+    const cfgStartColor = normalizedConfig.startColor;
 
     aColorR.array[particleIndex] =
-      startColor.min!.r! +
-      colorRandomRatio * (startColor.max!.r! - startColor.min!.r!);
+      cfgStartColor.min!.r! +
+      colorRandomRatio * (cfgStartColor.max!.r! - cfgStartColor.min!.r!);
     aColorR.needsUpdate = true;
 
     aColorG.array[particleIndex] =
-      startColor.min!.g! +
-      colorRandomRatio * (startColor.max!.g! - startColor.min!.g!);
+      cfgStartColor.min!.g! +
+      colorRandomRatio * (cfgStartColor.max!.g! - cfgStartColor.min!.g!);
     aColorG.needsUpdate = true;
 
     aColorB.array[particleIndex] =
-      startColor.min!.b! +
-      colorRandomRatio * (startColor.max!.b! - startColor.min!.b!);
+      cfgStartColor.min!.b! +
+      colorRandomRatio * (cfgStartColor.max!.b! - cfgStartColor.min!.b!);
     aColorB.needsUpdate = true;
 
     generalData.startValues.startColorR[particleIndex] =
@@ -1146,26 +1147,27 @@ export const createParticleSystem = (
     generalData.startValues.startColorB[particleIndex] =
       aColorB.array[particleIndex];
 
-    aStartFrame.array[particleIndex] = textureSheetAnimation.startFrame
-      ? calculateValue(
-          generalData.particleSystemId,
-          textureSheetAnimation.startFrame,
-          0
-        )
-      : 0;
+    aStartFrame.array[particleIndex] =
+      normalizedConfig.textureSheetAnimation.startFrame
+        ? calculateValue(
+            generalData.particleSystemId,
+            normalizedConfig.textureSheetAnimation.startFrame,
+            0
+          )
+        : 0;
     aStartFrame.needsUpdate = true;
 
     aStartLifetime.array[particleIndex] =
       calculateValue(
         generalData.particleSystemId,
-        startLifetime,
+        normalizedConfig.startLifetime,
         generalData.normalizedLifetimePercentage
       ) * 1000;
     aStartLifetime.needsUpdate = true;
 
     generalData.startValues.startSize[particleIndex] = calculateValue(
       generalData.particleSystemId,
-      startSize,
+      normalizedConfig.startSize,
       generalData.normalizedLifetimePercentage
     );
     aSize.array[particleIndex] =
@@ -1174,7 +1176,7 @@ export const createParticleSystem = (
 
     generalData.startValues.startOpacity[particleIndex] = calculateValue(
       generalData.particleSystemId,
-      startOpacity,
+      normalizedConfig.startOpacity,
       generalData.normalizedLifetimePercentage
     );
     aColorA.array[particleIndex] =
@@ -1183,7 +1185,7 @@ export const createParticleSystem = (
 
     aRotation.array[particleIndex] = calculateValue(
       generalData.particleSystemId,
-      startRotation,
+      normalizedConfig.startRotation,
       generalData.normalizedLifetimePercentage
     );
     aRotation.needsUpdate = true;
@@ -1209,8 +1211,8 @@ export const createParticleSystem = (
 
     calculatePositionAndVelocity(
       generalData,
-      shape,
-      startSpeed,
+      normalizedConfig.shape,
+      normalizedConfig.startSpeed,
       startPositions[particleIndex],
       velocities[particleIndex]
     );

--- a/src/js/effects/three-particles/types.ts
+++ b/src/js/effects/three-particles/types.ts
@@ -1726,6 +1726,39 @@ export type ParticleSystem = {
   pauseEmitter: () => void;
   dispose: () => void;
   update: (cycleData: CycleData) => void;
+  /**
+   * Updates the particle system configuration at runtime without recreating the system.
+   *
+   * System-level properties (gravity, force fields, noise, emission rates, color/size/opacity
+   * over lifetime curves) take effect immediately for all particles.
+   * Per-particle spawn properties (startColor, startSize, startSpeed, startLifetime, etc.)
+   * only affect newly emitted particles — already-alive particles retain their original values.
+   *
+   * @param config - A partial configuration object. Only the provided properties will be updated;
+   *   all other settings remain unchanged.
+   *
+   * @remarks
+   * Structural properties that are set at creation time cannot be changed at runtime:
+   * `maxParticles`, `renderer.rendererType`, `shape`, and `map` (texture).
+   * Passing these will update the internal config but have no visible effect since the
+   * geometry and material are pre-allocated.
+   *
+   * @example
+   * ```typescript
+   * const system = createParticleSystem(config);
+   *
+   * // Change wind direction in real time
+   * system.updateConfig({
+   *   forceFields: [{ type: ForceFieldType.DIRECTIONAL, direction: { x: 1, y: 0, z: 0 }, strength: 5 }],
+   * });
+   *
+   * // Gradually change color of new particles
+   * system.updateConfig({
+   *   startColor: { min: { r: 1, g: 0, b: 0 }, max: { r: 1, g: 0.5, b: 0 } },
+   * });
+   * ```
+   */
+  updateConfig: (config: Partial<ParticleSystemConfig>) => void;
 };
 
 /**


### PR DESCRIPTION
Allow modifying particle system configuration at runtime without
recreating the system. System-level properties (gravity, force fields,
noise, emission rates, lifetime curves) take effect immediately.
Per-particle spawn properties (startColor, startSize, etc.) affect
only newly emitted particles.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_017ibzv5xeoSURASQfSzXECf